### PR TITLE
Add PyPI badge to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![PyPi](https://img.shields.io/pypi/v/overturemaps.svg)](https://pypi.python.org/pypi/overturemaps)
+
 # overturemaps-py
 
 Official Python command-line tool of the [Overture Maps Foundation](https://overturemaps.org)


### PR DESCRIPTION
Add a PyPI badge to the Readme to show most recent version available on PyPI. This helps users to quickly find the latest released version.

[![PyPi](https://img.shields.io/pypi/v/overturemaps.svg)](https://pypi.python.org/pypi/overturemaps)