### PR TITLE
Add pypi publish action

### DIFF
--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -1,0 +1,51 @@
+on:
+  push:
+    branches: [main]
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  build-package:
+    name: Build & verify package
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: hynek/build-and-inspect-python-package@v2
+
+  release-test-pypi:
+    name: Publish package to test.pypi.org
+    environment: release-test-pypi
+    if: github.repository_owner == 'OvertureMaps' && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    needs: build-package
+    steps:
+      - name: Download packages built by build-and-inspect-python-package
+        uses: actions/download-artifact@v4
+        with:
+          name: Packages
+          path: dist
+      - name: Upload package to Test PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+
+  release-pypi:
+    name: Publish released package to pypi.org
+    environment: release-pypi
+    if: github.repository_owner == 'OvertureMaps' && github.event.action == 'published'
+    runs-on: ubuntu-latest
+    needs: build-package
+    steps:
+      - name: Download packages built by build-and-inspect-python-package
+        uses: actions/download-artifact@v4
+        with:
+          name: Packages
+          path: dist
+      - name: Upload package to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
This needs [trusted publishers](https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers/) setup first but should allow for automated publishing when a new release is made.

The general workflow around release could look like:
1) Update to the latest release path
2) Prepare a draft release with any release notes
3) Publish release when announcement post is live to rev pypi