### PR TITLE
feature: Add release version parameter

### DIFF
--- a/overturemaps/core.py
+++ b/overturemaps/core.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import List, Optional, Tuple, TypeAlias
 
 import pyarrow as pa
 import pyarrow.compute as pc
@@ -6,7 +6,7 @@ import pyarrow.dataset as ds
 import pyarrow.fs as fs
 
 # Allows for optional import of additional dependencies
-try: 
+try:
     import geopandas as gpd
     from geopandas import GeoDataFrame
     HAS_GEOPANDAS = True
@@ -14,11 +14,14 @@ except ImportError:
     HAS_GEOPANDAS = False
     GeoDataFrame = None
 
-def record_batch_reader(overture_type, bbox=None) -> Optional[pa.RecordBatchReader]:
+BoundingBox: TypeAlias = Tuple[float, float, float, float]
+default_release = "2024-12-18.0"
+
+def record_batch_reader(overture_type: str, bbox: BoundingBox | None = None, release: str = default_release) -> Optional[pa.RecordBatchReader]:
     """
     Return a pyarrow RecordBatchReader for the desired bounding box and s3 path
     """
-    path = _dataset_path(overture_type)
+    path = _dataset_path(overture_type, release=release)
 
     if bbox:
         xmin, ymin, xmax, ymax = bbox
@@ -48,7 +51,7 @@ def record_batch_reader(overture_type, bbox=None) -> Optional[pa.RecordBatchRead
     reader = pa.RecordBatchReader.from_batches(geoarrow_schema, non_empty_batches)
     return reader
 
-def geodataframe(overture_type: str, bbox: (float, float, float, float) = None) -> GeoDataFrame:
+def geodataframe(overture_type: str, bbox: BoundingBox | None = None, release: str = default_release) -> GeoDataFrame:
     """
     Loads geoparquet for specified type into a geopandas dataframe
 
@@ -56,6 +59,7 @@ def geodataframe(overture_type: str, bbox: (float, float, float, float) = None) 
     ----------
     overture_type: type to load
     bbox: optional bounding box for data fetch (xmin, ymin, xmax, ymax)
+    release: optional release to load (default is latest)
 
     Returns
     -------
@@ -65,7 +69,7 @@ def geodataframe(overture_type: str, bbox: (float, float, float, float) = None) 
     if not HAS_GEOPANDAS:
         raise ImportError("geopandas is required to use this function")
 
-    reader = record_batch_reader(overture_type, bbox)
+    reader = record_batch_reader(overture_type, bbox, release)
     return gpd.GeoDataFrame.from_arrow(reader)
 
 def geoarrow_schema_adapter(schema: pa.Schema) -> pa.Schema:
@@ -115,7 +119,7 @@ type_theme_map = {
 }
 
 
-def _dataset_path(overture_type: str) -> str:
+def _dataset_path(overture_type: str, release: str=default_release) -> str:
     """
     Returns the s3 path of the Overture dataset to use. This assumes overture_type has
     been validated, e.g. by the CLI
@@ -125,7 +129,7 @@ def _dataset_path(overture_type: str) -> str:
     # complete s3 path. Could be discovered by reading from the top-level s3
     # location but this allows to only read the files in the necessary partition.
     theme = type_theme_map[overture_type]
-    return f"overturemaps-us-west-2/release/2024-12-18.0/theme={theme}/type={overture_type}/"
+    return f"overturemaps-us-west-2/release/{release}/theme={theme}/type={overture_type}/"
 
 
 def get_all_overture_types() -> List[str]:


### PR DESCRIPTION
* My ETL Workflows handle multiple Overture releases. I need a way to specify which release I'm downloading otherwise rewrite this library
* This PR adds a parameter `release` that takes a string like `2024-12-18.0` which corresponds to an Overture release in S3
* Adds default values so it defaults to latest hardcoded `2024-12-18.0` ensuring backwards compatibility. No CLI code needs to be modified. Anyone who is using the latest library version can safely update
* When the default value needs to be updated, change the variable `default_release`
* Adds some enhanced Typing suggestions