### PR TITLE
fix record_batch_reader params in geodataframe

### DIFF
--- a/overturemaps/core.py
+++ b/overturemaps/core.py
@@ -24,6 +24,7 @@ try:
     HAS_GEOPANDAS = True
 except ImportError:
     HAS_GEOPANDAS = False
+    class GeoDataFrame: pass
 
 
 def _get_files_from_stac(theme: str, overture_type: str, bbox: tuple, release: str) -> Optional[List[str]]:


### PR DESCRIPTION
In core.py, geodataframe is calling record_batch_reader incorrectly

here is the function declaration:

def record_batch_reader(
    overture_type, bbox=None, release=None, connect_timeout=None, request_timeout=None, stac=False
) -> Optional[pa.RecordBatchReader]:

and here is how it's being called in geodataframe:

reader = record_batch_reader(overture_type, bbox, connect_timeout, request_timeout)

the connect_timeout is being passed through as the release and the request_timeout is being passed through as the connect_timeout, so if either of these are set it will cause unintended outcomes.

