### PR TITLE
Add incremental update with pyarrow (no backend abstraction)

### DIFF
--- a/overturemaps/changelog.py
+++ b/overturemaps/changelog.py
@@ -1,0 +1,271 @@
+"""Functions for querying and processing the Overture Maps GERS changelog.
+
+This module uses pyarrow for reading and filtering changelog data from S3.
+It supports STAC catalog acceleration when available.
+
+STAC Support
+------------
+This module is prepared to use the STAC catalog for accelerated spatial queries
+when changelog files are added to the STAC index. The _get_changelog_files_from_stac()
+function will automatically enable this optimization once the catalog includes changelog
+partitions. Until then, queries fall back to direct S3 path scanning.
+
+See: https://stac.overturemaps.org/
+"""
+
+from __future__ import annotations
+
+import io
+from typing import Optional
+from urllib.request import urlopen
+
+import pyarrow as pa
+import pyarrow.compute as pc
+import pyarrow.dataset as ds
+import pyarrow.fs as fs
+import pyarrow.parquet as pq
+
+from .models import BBox
+
+# S3 path template for the changelog Parquet files
+CHANGELOG_S3_PATH_TEMPLATE = "overturemaps-us-west-2/changelog/{release}/theme={theme}/type={type}/"
+
+
+def _get_changelog_files_from_stac(
+    theme: str, type_: str, bbox: BBox, release: str
+) -> Optional[list[str]]:
+    """Get changelog file paths from STAC catalog for spatial query optimization.
+
+    This function checks the STAC catalog for changelog file entries and returns
+    only the files whose bounding boxes intersect with the query bbox. This can
+    dramatically reduce query time by avoiding full S3 partition scans.
+
+    NOTE: As of early 2026, changelog files are not yet included in the STAC catalog.
+    This function is prepared for when that feature becomes available. Until then,
+    it returns None, causing queries to fall back to direct S3 path scanning.
+
+    Args:
+        theme: Overture theme name (e.g., "buildings").
+        type_: Overture feature type (e.g., "building").
+        bbox: Bounding box for spatial filtering.
+        release: Overture release ID (e.g., "2025-01-21.0").
+
+    Returns:
+        List of S3 paths (bucket/key format) if STAC has changelog data, None otherwise.
+    """
+    stac_changelog_url = f"https://stac.overturemaps.org/{release}/changelog.parquet"
+
+    try:
+        # Try to read the STAC changelog index
+        with urlopen(stac_changelog_url) as response:
+            data = response.read()
+            buffer = io.BytesIO(data)
+            stac_table = pq.read_table(buffer)
+
+        # Filter by theme/type
+        feature_type_filter = (pc.field("theme") == theme) & (pc.field("type") == type_)
+
+        # Spatial filter: only include files whose bbox overlaps query bbox
+        bbox_filter = (
+            (pc.field("bbox", "xmin") < bbox.xmax)
+            & (pc.field("bbox", "xmax") > bbox.xmin)
+            & (pc.field("bbox", "ymin") < bbox.ymax)
+            & (pc.field("bbox", "ymax") > bbox.ymin)
+        )
+
+        combined_filter = feature_type_filter & bbox_filter
+        filtered_table = stac_table.filter(combined_filter)
+
+        if filtered_table.num_rows > 0:
+            # Extract S3 paths
+            file_paths = filtered_table.column("assets").to_pylist()
+            s3_paths = [
+                path["aws"]["alternate"]["s3"]["href"][len("s3://") :]
+                for path in file_paths
+            ]
+            return s3_paths
+        else:
+            # No matching files in this region
+            return []
+
+    except Exception:
+        # STAC changelog not available yet, return None to trigger fallback
+        return None
+
+
+def query_changelog_ids(
+    release: str,
+    theme: str,
+    type_: str,
+    bbox: BBox,
+) -> tuple[set[str], set[str], set[str]]:
+    """Query changelog and return classified ID sets using pyarrow.
+
+    This function reads changelog Parquet files from S3 and returns sets of IDs
+    for added, modified, and removed features within the specified bbox.
+
+    Automatically attempts to use STAC catalog for query acceleration. When changelog
+    files are added to STAC, this will speed up spatial queries. Until then, transparently
+    falls back to direct S3 access.
+
+    Args:
+        release: Overture release ID (e.g. "2024-11-13.0").
+        theme: Overture theme name (e.g. "buildings").
+        type_: Overture feature type (e.g. "building").
+        bbox: Bounding box to spatially filter changes.
+
+    Returns:
+        Tuple of (ids_to_add, ids_to_modify, ids_to_delete) as sets of feature IDs.
+    """
+    # Try STAC first (will automatically work when changelog added to STAC)
+    s3_paths = _get_changelog_files_from_stac(theme, type_, bbox, release)
+
+    # Create S3 filesystem
+    s3_fs = fs.S3FileSystem(anonymous=True, region="us-west-2")
+
+    # Use STAC paths if available, otherwise use full partition path
+    if s3_paths is not None:
+        if len(s3_paths) == 0:
+            # No files intersect the bbox
+            return set(), set(), set()
+        # Use specific files from STAC
+        dataset_path = s3_paths
+    else:
+        # STAC not available, use full path pattern
+        dataset_path = CHANGELOG_S3_PATH_TEMPLATE.format(
+            release=release, theme=theme, type=type_
+        )
+
+    try:
+        # Create dataset
+        dataset = ds.dataset(
+            dataset_path,
+            filesystem=s3_fs,
+            format="parquet",
+            partitioning="hive",
+        )
+
+        # Build spatial filter
+        spatial_filter = (
+            (pc.field("bbox", "xmin") <= bbox.xmax)
+            & (pc.field("bbox", "xmax") >= bbox.xmin)
+            & (pc.field("bbox", "ymin") <= bbox.ymax)
+            & (pc.field("bbox", "ymax") >= bbox.ymin)
+            & (pc.field("change_type") != "unchanged")
+        )
+
+        # Read only id and change_type columns with filter
+        table = dataset.to_table(
+            filter=spatial_filter, columns=["id", "change_type"]
+        )
+
+        # Group IDs by change_type
+        ids_to_add: set[str] = set()
+        ids_to_modify: set[str] = set()
+        ids_to_delete: set[str] = set()
+
+        if table.num_rows > 0:
+            ids = table.column("id").to_pylist()
+            change_types = table.column("change_type").to_pylist()
+
+            for id_, change_type in zip(ids, change_types):
+                if change_type == "added":
+                    ids_to_add.add(id_)
+                elif change_type == "data_changed":
+                    ids_to_modify.add(id_)
+                elif change_type == "removed":
+                    ids_to_delete.add(id_)
+
+        return ids_to_add, ids_to_modify, ids_to_delete
+
+    except Exception as e:
+        # If no data found, return empty sets
+        if "No such file" in str(e) or "does not exist" in str(e):
+            return set(), set(), set()
+        raise
+
+
+def summarize_changelog(
+    release: str,
+    theme: str | None = None,
+    type_: str | None = None,
+) -> dict[str, dict[str, dict[str, int]]]:
+    """Return change counts by type for one or more themes without bbox filtering.
+
+    Args:
+        release: Overture release ID.
+        theme: Overture theme name (optional, defaults to all themes).
+        type_: Overture feature type (optional, defaults to all types in theme).
+
+    Returns:
+        Nested dictionary: {theme: {type: {change_type: count}}}.
+    """
+    from .core import type_theme_map
+
+    results = {}
+    s3_fs = fs.S3FileSystem(anonymous=True, region="us-west-2")
+
+    # Determine which theme/type combinations to query
+    if theme and type_:
+        themes_types = [(theme, type_)]
+    elif theme:
+        types = _get_types_for_theme(theme)
+        themes_types = [(theme, t) for t in types]
+    elif type_:
+        if type_ not in type_theme_map:
+            raise ValueError(f"Unknown type: {type_}")
+        theme = type_theme_map[type_]
+        themes_types = [(theme, type_)]
+    else:
+        themes_types = [(type_theme_map[t], t) for t in sorted(type_theme_map.keys())]
+
+    # Query each theme/type combination
+    for theme_name, type_name in themes_types:
+        dataset_path = CHANGELOG_S3_PATH_TEMPLATE.format(
+            release=release, theme=theme_name, type=type_name
+        )
+
+        try:
+            dataset = ds.dataset(
+                dataset_path,
+                filesystem=s3_fs,
+                format="parquet",
+                partitioning="hive",
+            )
+
+            # Read only change_type column
+            table = dataset.to_table(columns=["change_type"])
+
+            # Count by change_type
+            change_counts = {}
+            if table.num_rows > 0:
+                change_types = table.column("change_type").to_pylist()
+                for ct in set(change_types):
+                    change_counts[ct] = change_types.count(ct)
+
+            # Build nested structure
+            if theme_name not in results:
+                results[theme_name] = {}
+            results[theme_name][type_name] = change_counts
+
+        except Exception as e:
+            # If a theme/type doesn't have changelog data, skip it
+            if "No such file" in str(e) or "does not exist" in str(e):
+                continue
+            raise
+
+    return results
+
+
+def _get_types_for_theme(theme: str) -> list[str]:
+    """Get all feature types for a given theme.
+
+    Args:
+        theme: Overture theme name.
+
+    Returns:
+        List of feature types in the theme.
+    """
+    from .core import type_theme_map
+
+    return [type_ for type_, t in type_theme_map.items() if t == theme]

--- a/overturemaps/cli.py
+++ b/overturemaps/cli.py
@@ -22,7 +22,14 @@ from .core import (
     get_latest_release,
     record_batch_reader,
     record_batch_reader_from_gers,
+    type_theme_map,
 )
+from .releases import list_releases
+from .models import BBox, Backend, PipelineState
+from .state import get_state_path, save_state, load_state
+from .update import apply_update
+from datetime import datetime, timezone
+from pathlib import Path
 
 
 def get_writer(output_format, path, schema):
@@ -161,7 +168,9 @@ def download(
         )
 
     if output is None:
-        output = sys.stdout
+        output_file = sys.stdout
+    else:
+        output_file = output
 
     reader = record_batch_reader(
         type_, bbox, release, connect_timeout, request_timeout, stac
@@ -170,8 +179,34 @@ def download(
     if reader is None:
         return
 
-    with get_writer(output_format, output, schema=reader.schema) as writer:
+    with get_writer(output_format, output_file, schema=reader.schema) as writer:
         copy(reader, writer)
+
+    # Save state file if output was written to a file
+    if output is not None and bbox is not None:
+        # Determine backend from output format
+        backend = Backend(output_format)
+        
+        # Get theme from type
+        theme = type_theme_map.get(type_)
+        if theme is None:
+            click.echo(f"Warning: Could not determine theme for type {type_}", err=True)
+            return
+        
+        # Create and save state
+        state = PipelineState(
+            last_release=release,
+            last_run=datetime.now(timezone.utc).isoformat(),
+            theme=theme,
+            type=type_,
+            bbox=BBox(xmin=bbox[0], ymin=bbox[1], xmax=bbox[2], ymax=bbox[3]),
+            backend=backend,
+            output=output,
+        )
+        
+        state_path = get_state_path(output)
+        save_state(state, state_path)
+        click.echo(f"State saved to {state_path}", err=True)
 
 
 @cli.command()
@@ -326,6 +361,153 @@ class GeoJSONWriter(BaseGeoJSONWriter):
 
     def finalize(self):
         self.writer.write("]}")
+
+
+@cli.group()
+def releases():
+    """Manage and query Overture Maps releases."""
+    pass
+
+
+@releases.command(name="list")
+def releases_list():
+    """List all available Overture Maps releases."""
+    all_releases = list_releases()
+    if not all_releases:
+        click.echo("No releases found.", err=True)
+        return
+    for release in all_releases:
+        click.echo(release)
+
+
+@releases.command(name="latest")
+def releases_latest():
+    """Show the latest Overture Maps release."""
+    latest = get_latest_release()
+    click.echo(latest)
+
+
+@cli.group()
+def update():
+    """Incremental update commands."""
+    pass
+
+
+@update.command(name="run")
+@click.option("-o", "--output", required=True, type=click.Path(exists=True))
+@click.option(
+    "-r",
+    "--release",
+    default=None,
+    callback=validate_release,
+    required=False,
+    help="Target release (defaults to latest)",
+)
+@click.option("--bbox", required=False, type=BboxParamType(), help="Override bbox from state file")
+def update_run(output, release, bbox):
+    """Run incremental update on a local file.
+    
+    Reads parameters from the state file and applies changes from the changelog.
+    
+    Examples:
+        overturemaps update run -o ~/data/buildings.parquet
+        overturemaps update run -o ~/data/buildings.parquet --release=2024-11-13.0
+    """
+    output_path = Path(output)
+    state_path = get_state_path(output_path)
+    
+    # Load state
+    state = load_state(state_path)
+    if state is None:
+        click.echo(f"Error: No state file found at {state_path}", err=True)
+        click.echo("State files are created automatically when using 'overturemaps download' with -o flag.", err=True)
+        sys.exit(1)
+    
+    # Determine target release
+    if release is None:
+        release = get_latest_release()
+    
+    # Check if already up to date
+    if state.last_release == release:
+        click.echo(f"Already up to date at release {release}", err=True)
+        return
+    
+    # Override bbox if provided
+    if bbox is not None:
+        state.bbox = BBox(xmin=bbox[0], ymin=bbox[1], xmax=bbox[2], ymax=bbox[3])
+    
+    click.echo(f"Updating {state.last_release} → {release}...", err=True)
+    click.echo(f"Theme: {state.theme}, Type: {state.type}", err=True)
+    click.echo(f"Bbox: {state.bbox.as_tuple()}", err=True)
+    click.echo()
+    
+    # Apply update
+    try:
+        stats = apply_update(
+            output_path,
+            release,
+            state.theme,
+            state.type,
+            state.bbox,
+            state.backend,
+            from_release=state.last_release,
+        )
+        
+        click.echo(f"Update complete:", err=True)
+        click.echo(f"  Added:    {stats['added']}", err=True)
+        click.echo(f"  Modified: {stats['modified']}", err=True)
+        click.echo(f"  Deleted:  {stats['deleted']}", err=True)
+        click.echo(f"  Original: {stats['original_count']} features", err=True)
+        click.echo(f"  Final:    {stats['final_count']} features", err=True)
+        
+        # Update state file
+        state.last_release = release
+        state.last_run = datetime.now(timezone.utc).isoformat()
+        save_state(state, state_path)
+        click.echo(f"\nState saved to {state_path}", err=True)
+        
+    except Exception as e:
+        click.echo(f"Error during update: {e}", err=True)
+        import traceback
+        traceback.print_exc()
+        sys.exit(1)
+
+
+@update.command(name="status")
+@click.option("-o", "--output", required=True, type=click.Path(exists=True))
+def update_status(output):
+    """Show current pipeline state for a local file.
+    
+    Examples:
+        overturemaps update status -o ~/data/buildings.parquet
+    """
+    output_path = Path(output)
+    state_path = get_state_path(output_path)
+    
+    state = load_state(state_path)
+    if state is None:
+        click.echo(f"No state file found at {state_path}", err=True)
+        sys.exit(1)
+    
+    latest = get_latest_release()
+    
+    click.echo(f"File: {output_path}")
+    click.echo(f"State file: {state_path}")
+    click.echo()
+    click.echo(f"Current release: {state.last_release}")
+    click.echo(f"Latest release:  {latest}")
+    click.echo(f"Last run:        {state.last_run}")
+    click.echo()
+    click.echo(f"Theme:   {state.theme}")
+    click.echo(f"Type:    {state.type}")
+    click.echo(f"Backend: {state.backend}")
+    click.echo(f"Bbox:    {state.bbox.as_tuple()}")
+    click.echo()
+    
+    if state.last_release == latest:
+        click.echo("Status: ✓ Up to date")
+    else:
+        click.echo("Status: ✗ Update available")
 
 
 if __name__ == "__main__":

--- a/overturemaps/models.py
+++ b/overturemaps/models.py
@@ -1,0 +1,117 @@
+"""Data models for the Overture toolkit."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+
+# Compatibility shim for Python 3.10 (StrEnum was added in 3.11)
+try:
+    from enum import StrEnum
+except ImportError:
+
+    class StrEnum(str, Enum):
+        """String enumeration for Python < 3.11 compatibility."""
+
+        def __str__(self) -> str:
+            return str(self.value)
+
+        @staticmethod
+        def _generate_next_value_(name, start, count, last_values):
+            return name.lower()
+
+
+class ChangeType(StrEnum):
+    """Type of change recorded in the GERS changelog."""
+
+    added = "added"
+    modified = "data_changed"  # Changelog uses "data_changed"
+    removed = "removed"
+
+
+class Backend(StrEnum):
+    """Storage backend for local Overture data."""
+
+    geojson = "geojson"
+    geojsonseq = "geojsonseq"
+    geoparquet = "geoparquet"
+
+
+@dataclass
+class BBox:
+    """Axis-aligned bounding box (WGS84 lon/lat)."""
+
+    xmin: float
+    ymin: float
+    xmax: float
+    ymax: float
+
+    def as_tuple(self) -> tuple[float, float, float, float]:
+        """Return (xmin, ymin, xmax, ymax) tuple."""
+        return (self.xmin, self.ymin, self.xmax, self.ymax)
+
+    def as_dict(self) -> dict[str, float]:
+        """Return bbox as a dictionary."""
+        return {
+            "xmin": self.xmin,
+            "ymin": self.ymin,
+            "xmax": self.xmax,
+            "ymax": self.ymax,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, float]) -> BBox:
+        """Create BBox from a dictionary."""
+        return cls(
+            xmin=data["xmin"],
+            ymin=data["ymin"],
+            xmax=data["xmax"],
+            ymax=data["ymax"],
+        )
+
+
+@dataclass
+class ChangeRecord:
+    """A single record from the Overture GERS changelog."""
+
+    id: str
+    change_type: ChangeType
+    bbox: BBox | None = None
+
+
+@dataclass
+class PipelineState:
+    """Persistent state tracking for a download pipeline."""
+
+    last_release: str
+    last_run: str  # ISO 8601 datetime string
+    theme: str
+    type: str
+    bbox: BBox
+    backend: Backend
+    output: str  # file path
+
+    def as_dict(self) -> dict:
+        """Convert state to a dictionary for JSON serialization."""
+        return {
+            "last_release": self.last_release,
+            "last_run": self.last_run,
+            "theme": self.theme,
+            "type": self.type,
+            "bbox": self.bbox.as_dict(),
+            "backend": str(self.backend),
+            "output": self.output,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> PipelineState:
+        """Create PipelineState from a dictionary."""
+        return cls(
+            last_release=data["last_release"],
+            last_run=data["last_run"],
+            theme=data["theme"],
+            type=data["type"],
+            bbox=BBox.from_dict(data["bbox"]),
+            backend=Backend(data["backend"]),
+            output=data["output"],
+        )

--- a/overturemaps/releases.py
+++ b/overturemaps/releases.py
@@ -1,0 +1,74 @@
+"""Functions for listing and querying Overture Maps releases."""
+
+from __future__ import annotations
+
+from .core import get_available_releases as _get_available_releases_from_stac
+
+
+def list_releases() -> list[str]:
+    """List all available Overture Maps release IDs, newest first.
+
+    Uses the STAC catalog for efficient retrieval.
+
+    Returns:
+        Sorted list of release IDs (e.g. ["2024-11-13.0", "2024-10-23.0", ...]).
+    """
+    releases, _ = _get_available_releases_from_stac()
+    # Sort descending so newest is first
+    return sorted(releases, reverse=True)
+
+
+def get_latest_release() -> str:
+    """Return the ID of the most recent Overture Maps release.
+
+    Uses the STAC catalog for efficient retrieval.
+
+    Returns:
+        Latest release ID string.
+
+    Raises:
+        RuntimeError: If no releases are found.
+    """
+    releases, latest = _get_available_releases_from_stac()
+    if not latest and not releases:
+        raise RuntimeError("No Overture Maps releases found.")
+    return latest or releases[0]
+
+
+def release_exists(release: str) -> bool:
+    """Check whether a given release ID exists.
+
+    Uses the STAC catalog.
+
+    Args:
+        release: Release ID to check (e.g. "2024-11-13.0").
+
+    Returns:
+        True if the release exists, False otherwise.
+    """
+    try:
+        releases, _ = _get_available_releases_from_stac()
+        return release in releases
+    except Exception:
+        return False
+
+
+def get_next_release(current_release: str) -> str | None:
+    """Get the release that comes immediately after the given release.
+
+    Args:
+        current_release: A release ID (e.g. "2025-12-17.0").
+
+    Returns:
+        The next release ID, or None if current_release is the latest.
+    """
+    releases = list_releases()  # Returns newest first
+    try:
+        current_idx = releases.index(current_release)
+        # Since list is newest first, next release is at index - 1
+        if current_idx > 0:
+            return releases[current_idx - 1]
+        return None  # Already at latest
+    except ValueError:
+        # Current release not found
+        return None

--- a/overturemaps/state.py
+++ b/overturemaps/state.py
@@ -1,0 +1,58 @@
+"""Pipeline state management for tracking downloads and updates."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Optional
+
+from .models import PipelineState
+
+
+def get_state_path(output_path: str) -> Path:
+    """Get the state file path for a given output file.
+
+    Args:
+        output_path: Path to the output file.
+
+    Returns:
+        Path to the state file (output_path + ".state").
+    """
+    return Path(f"{output_path}.state")
+
+
+def load_state(state_path: Path | str) -> Optional[PipelineState]:
+    """Load pipeline state from a JSON file.
+
+    Args:
+        state_path: Path to the state file.
+
+    Returns:
+        PipelineState object if file exists, None otherwise.
+    """
+    state_path = Path(state_path)
+    if not state_path.exists():
+        return None
+
+    try:
+        with open(state_path, "r") as f:
+            data = json.load(f)
+        return PipelineState.from_dict(data)
+    except (json.JSONDecodeError, KeyError, FileNotFoundError):
+        return None
+
+
+def save_state(state: PipelineState, state_path: Path | str) -> None:
+    """Save pipeline state to a JSON file.
+
+    Args:
+        state: PipelineState object to save.
+        state_path: Path to the state file.
+    """
+    state_path = Path(state_path)
+    # Create parent directory if it doesn't exist
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with open(state_path, "w") as f:
+        json.dump(state.as_dict(), f, indent=2)

--- a/overturemaps/update.py
+++ b/overturemaps/update.py
@@ -1,0 +1,249 @@
+"""Incremental update functionality using pyarrow.
+
+This module implements the core update logic following jwass's feedback:
+1. Read existing local file as pyarrow Table
+2. Query changelog for IDs (added, modified, removed)
+3. Fetch new/modified features from S3 using pyarrow.dataset
+4. Filter out removed+modified from existing using pyarrow.compute.is_in
+5. Concatenate kept features + new features
+6. Write back using appropriate writer
+
+No backend abstraction - just direct pyarrow table operations.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Optional
+
+import pyarrow as pa
+import pyarrow.compute as pc
+import pyarrow.dataset as ds
+import pyarrow.fs as fs
+import pyarrow.parquet as pq
+import shapely.wkb
+
+from .models import BBox, Backend
+from .changelog import query_changelog_ids
+from .core import type_theme_map
+
+
+def fetch_features_pyarrow(
+    release: str,
+    theme: str,
+    type_: str,
+    ids: set[str],
+    bbox: Optional[BBox] = None,
+) -> pa.Table:
+    """Fetch features from S3 using pyarrow by ID.
+
+    Args:
+        release: Overture release ID.
+        theme: Overture theme name.
+        type_: Overture feature type.
+        ids: Set of feature IDs to fetch.
+        bbox: Optional bounding box filter.
+
+    Returns:
+        PyArrow Table with the fetched features.
+    """
+    if not ids:
+        # Return empty table with no schema
+        return None
+
+    s3_fs = fs.S3FileSystem(anonymous=True, region="us-west-2")
+    dataset_path = f"overturemaps-us-west-2/release/{release}/theme={theme}/type={type_}/"
+
+    dataset = ds.dataset(
+        dataset_path,
+        filesystem=s3_fs,
+        format="parquet",
+        partitioning="hive",
+    )
+
+    # Build filter expression
+    filter_expr = pc.is_in(pc.field("id"), value_set=pa.array(list(ids)))
+
+    if bbox is not None:
+        bbox_filter = (
+            (pc.field("bbox", "xmin") < bbox.xmax)
+            & (pc.field("bbox", "xmax") > bbox.xmin)
+            & (pc.field("bbox", "ymin") < bbox.ymax)
+            & (pc.field("bbox", "ymax") > bbox.ymin)
+        )
+        filter_expr = filter_expr & bbox_filter
+
+    return dataset.to_table(filter=filter_expr)
+
+
+def read_local_file(path: Path, backend: Backend) -> Optional[pa.Table]:
+    """Read local file into a pyarrow Table.
+
+    Args:
+        path: Path to the local file.
+        backend: Backend type (geojson, geojsonseq, geoparquet).
+
+    Returns:
+        PyArrow Table with the data, or None if file doesn't exist.
+    """
+    if not path.exists():
+        return None
+
+    if backend == Backend.geoparquet:
+        return pq.read_table(path)
+    elif backend == Backend.geojsonseq:
+        return _read_geojsonseq(path)
+    elif backend == Backend.geojson:
+        return _read_geojson(path)
+    else:
+        raise ValueError(f"Unsupported backend: {backend}")
+
+
+def _read_geojsonseq(path: Path) -> pa.Table:
+    """Read GeoJSON Sequence file into a pyarrow Table.
+    
+    This is a simplified implementation. For production use, consider using
+    a proper GeoJSON reader or geopandas.
+    """
+    import json
+
+    features = []
+    with open(path, "r") as f:
+        for line in f:
+            if line.strip():
+                features.append(json.loads(line))
+
+    # Convert to pyarrow (simplified - would need proper geometry handling)
+    # For now, raise an error suggesting geoparquet for updates
+    raise NotImplementedError(
+        "GeoJSON Sequence updates not yet implemented. "
+        "Please use geoparquet format for incremental updates."
+    )
+
+
+def _read_geojson(path: Path) -> pa.Table:
+    """Read GeoJSON file into a pyarrow Table.
+    
+    This is a simplified implementation. For production use, consider using
+    a proper GeoJSON reader or geopandas.
+    """
+    import json
+
+    with open(path, "r") as f:
+        data = json.load(f)
+
+    # For now, raise an error suggesting geoparquet for updates
+    raise NotImplementedError(
+        "GeoJSON updates not yet implemented. "
+        "Please use geoparquet format for incremental updates."
+    )
+
+
+def write_local_file(
+    table: pa.Table, path: Path, backend: Backend, schema: Optional[pa.Schema] = None
+) -> None:
+    """Write pyarrow Table to local file.
+
+    Args:
+        table: PyArrow Table to write.
+        path: Path to write to.
+        backend: Backend type.
+        schema: Optional schema (used for geoparquet metadata).
+    """
+    if backend == Backend.geoparquet:
+        # Use the schema from the original file if available
+        if schema is not None:
+            table = table.cast(schema)
+        pq.write_table(table, path)
+    else:
+        raise NotImplementedError(
+            f"Writing to {backend} not yet implemented. "
+            "Please use geoparquet format for incremental updates."
+        )
+
+
+def apply_update(
+    output_path: Path,
+    release: str,
+    theme: str,
+    type_: str,
+    bbox: BBox,
+    backend: Backend,
+    from_release: Optional[str] = None,
+) -> dict[str, int]:
+    """Apply incremental update to a local file.
+
+    Args:
+        output_path: Path to the local file to update.
+        release: Target release to update to.
+        theme: Overture theme name.
+        type_: Overture feature type.
+        bbox: Bounding box for spatial filtering.
+        backend: Storage backend type.
+        from_release: Source release (optional, auto-detected from file).
+
+    Returns:
+        Dict with update statistics: {
+            "added": int,
+            "modified": int,
+            "deleted": int,
+            "final_count": int
+        }
+    """
+    # Read existing data
+    existing = read_local_file(output_path, backend)
+
+    if existing is None:
+        raise FileNotFoundError(f"File not found: {output_path}")
+
+    original_count = existing.num_rows
+    original_schema = existing.schema
+
+    # Query changelog for IDs
+    ids_to_add, ids_to_modify, ids_to_delete = query_changelog_ids(
+        release, theme, type_, bbox
+    )
+
+    # Fetch new and modified features
+    ids_to_fetch = ids_to_add | ids_to_modify
+
+    if ids_to_fetch:
+        new_features = fetch_features_pyarrow(release, theme, type_, ids_to_fetch, bbox)
+    else:
+        new_features = None
+
+    # Filter out removed + modified from existing
+    # (modified will be replaced with fresh versions from new_features)
+    ids_to_remove = ids_to_delete | ids_to_modify
+
+    if ids_to_remove:
+        existing_ids = existing.column("id")
+        # Create mask: keep rows where ID is NOT in ids_to_remove
+        mask = pc.invert(pc.is_in(existing_ids, value_set=pa.array(list(ids_to_remove))))
+        kept = existing.filter(mask)
+    else:
+        kept = existing
+
+    # Concatenate kept + new
+    if new_features is not None and new_features.num_rows > 0:
+        # Ensure schemas match (use original schema)
+        if new_features.schema != original_schema:
+            # Align columns
+            new_features = new_features.select(
+                [col for col in original_schema.names if col in new_features.schema.names]
+            )
+        updated = pa.concat_tables([kept, new_features])
+    else:
+        updated = kept
+
+    # Write back
+    write_local_file(updated, output_path, backend, schema=original_schema)
+
+    return {
+        "added": len(ids_to_add),
+        "modified": len(ids_to_modify),
+        "deleted": len(ids_to_delete),
+        "original_count": original_count,
+        "final_count": updated.num_rows,
+    }

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -1,0 +1,152 @@
+"""Tests for the update module."""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from overturemaps.models import BBox, Backend
+from overturemaps.update import apply_update, read_local_file, write_local_file
+from overturemaps.releases import get_latest_release
+
+
+def create_test_parquet(path: Path, ids: list[str]) -> None:
+    """Create a test geoparquet file with given IDs."""
+    # Create a simple schema
+    schema = pa.schema([
+        ("id", pa.string()),
+        ("name", pa.string()),
+        ("geometry", pa.binary()),
+        ("bbox", pa.struct([
+            ("xmin", pa.float64()),
+            ("ymin", pa.float64()),
+            ("xmax", pa.float64()),
+            ("ymax", pa.float64()),
+        ])),
+    ])
+    
+    # Create sample data
+    data = {
+        "id": ids,
+        "name": [f"Feature {i}" for i in range(len(ids))],
+        "geometry": [b"" for _ in ids],  # Empty WKB for testing
+        "bbox": [
+            {"xmin": -97.8, "ymin": 30.2, "xmax": -97.7, "ymax": 30.3}
+            for _ in ids
+        ],
+    }
+    
+    table = pa.table(data, schema=schema)
+    pq.write_table(table, path)
+
+
+def test_read_local_file_geoparquet():
+    """Test reading a local geoparquet file."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        test_file = Path(tmpdir) / "test.parquet"
+        create_test_parquet(test_file, ["id1", "id2", "id3"])
+        
+        table = read_local_file(test_file, Backend.geoparquet)
+        assert table is not None
+        assert table.num_rows == 3
+        assert "id" in table.column_names
+
+
+def test_read_local_file_nonexistent():
+    """Test reading a non-existent file returns None."""
+    result = read_local_file(Path("/nonexistent/file.parquet"), Backend.geoparquet)
+    assert result is None
+
+
+def test_write_local_file_geoparquet():
+    """Test writing a pyarrow table to geoparquet."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        test_file = Path(tmpdir) / "test.parquet"
+        
+        # Create a simple table
+        schema = pa.schema([
+            ("id", pa.string()),
+            ("name", pa.string()),
+        ])
+        data = {
+            "id": ["id1", "id2"],
+            "name": ["Feature 1", "Feature 2"],
+        }
+        table = pa.table(data, schema=schema)
+        
+        write_local_file(table, test_file, Backend.geoparquet)
+        assert test_file.exists()
+        
+        # Read it back
+        loaded = pq.read_table(test_file)
+        assert loaded.num_rows == 2
+
+
+@pytest.mark.integration
+def test_apply_update_geoparquet():
+    """Integration test for apply_update with geoparquet.
+    
+    This test requires network access to S3.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        test_file = Path(tmpdir) / "test.parquet"
+        
+        # Create a test file with some IDs
+        # Note: In a real scenario, these would be actual feature IDs from Overture
+        create_test_parquet(test_file, ["test_id_1", "test_id_2"])
+        
+        latest = get_latest_release()
+        bbox = BBox(xmin=-97.75, ymin=30.25, xmax=-97.74, ymax=30.26)
+        
+        # This will attempt to fetch real changelog data
+        # In practice, we'd want to mock this or use known test data
+        try:
+            stats = apply_update(
+                test_file,
+                latest,
+                "buildings",
+                "building",
+                bbox,
+                Backend.geoparquet,
+            )
+            
+            # Check that stats were returned
+            assert "added" in stats
+            assert "modified" in stats
+            assert "deleted" in stats
+            assert "final_count" in stats
+            
+        except Exception as e:
+            # If changelog data doesn't exist for this bbox, that's ok
+            if "No such file" in str(e) or "does not exist" in str(e):
+                pytest.skip("No changelog data for test bbox")
+            else:
+                raise
+
+
+def test_read_geojson_not_implemented():
+    """Test that GeoJSON reading raises NotImplementedError."""
+    with tempfile.NamedTemporaryFile(suffix=".geojson", mode="w", delete=False) as f:
+        f.write('{"type": "FeatureCollection", "features": []}')
+        temp_path = Path(f.name)
+    
+    try:
+        with pytest.raises(NotImplementedError):
+            read_local_file(temp_path, Backend.geojson)
+    finally:
+        temp_path.unlink()
+
+
+def test_read_geojsonseq_not_implemented():
+    """Test that GeoJSON Sequence reading raises NotImplementedError."""
+    with tempfile.NamedTemporaryFile(suffix=".geojsonl", mode="w", delete=False) as f:
+        f.write('{"type": "Feature"}\n')
+        temp_path = Path(f.name)
+    
+    try:
+        with pytest.raises(NotImplementedError):
+            read_local_file(temp_path, Backend.geojsonseq)
+    finally:
+        temp_path.unlink()


### PR DESCRIPTION
**PR 4 of 4: Incremental Update**

This PR adds the core incremental update functionality using pyarrow, following jwass's feedback to avoid per-format backend classes.

**New files:**
- `overturemaps/update.py` - Core update logic using pyarrow:
  - `apply_update()` - Main update function: read → join → filter → write
  - `fetch_features_pyarrow()` - Fetch features from S3 by ID using pyarrow.dataset
  - `read_local_file()` / `write_local_file()` - Simple I/O (geoparquet only for now)

**Modified files:**
- `overturemaps/cli.py` - Added:
  - `update run -o <file>` - Apply incremental update
  - `update status -o <file>` - Show current state
  - `download` command now saves `.state` file when `-o` is used

**Update Algorithm (following jwass's guidance):**
1. Read existing local file as pyarrow Table
2. Query changelog for (added_ids, modified_ids, removed_ids)
3. Fetch new/modified features from S3 using `pyarrow.dataset`
4. Filter out removed+modified from existing using `pc.is_in`
5. `pa.concat_tables([kept, new_features])`
6. Write back using `pq.write_table()`

**CLI Examples:**
```bash
# Initial download with state tracking
overturemaps download --bbox=-97.8,30.2,-97.6,30.4 --type=building -f geoparquet -o buildings.parquet
# Creates: buildings.parquet and buildings.parquet.state

# Apply incremental update
overturemaps update run -o buildings.parquet
# Reads state, queries changelog, applies changes

# Check status
overturemaps update status -o buildings.parquet
```

**Implementation:**
- ✅ Uses **pyarrow tables** directly (no geopandas for core logic)
- ✅ Uses **pyarrow.dataset** to fetch from S3 (NOT DuckDB)
- ✅ Uses **pyarrow.compute.is_in** for filtering
- ✅ **NO BaseBackend abstraction** - direct pyarrow operations
- ✅ **NO DuckDB dependency**
- ✅ Currently supports geoparquet only (GeoJSON support deferred)

**Tests:**
- `tests/test_update.py` - Unit and integration tests for update logic

**Dependencies:**
- ✅ No new dependencies (uses pyarrow only)
- Depends on: PR #87 (releases), PR #88 (state), PR #89 (changelog)

**Related PRs:**
- Depends on: PR #87, #88, #89
- Future work: GeoJSON/GeoJSONSeq support, PostGIS backend (separate PR)

**Key differences from PR #85:**
- No `BaseBackend` / `GeoParquetBackend` / `PostGISBackend` abstraction
- No `fetch.py` with DuckDB - uses pyarrow.dataset directly in `update.py`
- Simpler, more direct implementation as per jwass's feedback
- Focus on geoparquet first (most common use case)