### PR TITLE
[FEATURE] Download progress bar

### DIFF
--- a/benchmarks/bench_count_rows.py
+++ b/benchmarks/bench_count_rows.py
@@ -18,7 +18,7 @@ BBOX_SMALL = (-71.068, 42.353, -71.058, 42.363)  # ~10 blocks
 BBOX_BOSTON = (-71.191, 42.227, -70.985, 42.400)  # full city
 
 
-@pytest.mark.network
+@pytest.mark.integration
 def test_count_rows_small(benchmark):
     """count_rows overhead for a small bbox (~10 blocks)."""
     benchmark.pedantic(
@@ -26,7 +26,7 @@ def test_count_rows_small(benchmark):
     )
 
 
-@pytest.mark.network
+@pytest.mark.integration
 def test_count_rows_city(benchmark):
     """count_rows overhead for a full city bbox."""
     benchmark.pedantic(

--- a/justfile
+++ b/justfile
@@ -1,0 +1,57 @@
+#!/usr/bin/env just --justfile
+
+latest_release := `curl -s https://stac.overturemaps.org | jq -r '.latest'`
+
+@_default:
+    {{ just_executable() }} --list
+
+# Install all dependencies (including dev)
+[group('setup')]
+install:
+    uv sync --dev
+
+# Run unit tests only (no network)
+[group('test')]
+test:
+    uv run pytest tests/ -m "not integration"
+
+# Run the full test suite including integration tests
+[group('test')]
+test-all:
+    uv run pytest tests/
+
+# Run a quick CLI smoke test against the Boston bounding box
+[group('test')]
+smoke-test:
+    uv run overturemaps download \
+        --bbox=-71.068,42.353,-71.058,42.363 \
+        -f geojson \
+        --type=building \
+        -o /tmp/boston-smoke.geojson
+    @echo "Output written to /tmp/boston-smoke.geojson"
+
+# Run a smoke test for a given type (default: building)
+[group('test')]
+[arg('type', pattern='building|place|segment|connector|locality|locality_area|administrative_boundary|land|land_cover|land_use|water')]
+smoke-test-type type='building':
+    uv run overturemaps download \
+        --bbox=-71.068,42.353,-71.058,42.363 \
+        -f geojson \
+        --type={{ type }} \
+        -o /tmp/boston-{{ type }}.geojson
+    @echo "Output written to /tmp/boston-{{ type }}.geojson"
+
+# Show the latest Overture release
+[group('release')]
+latest:
+    @echo {{ latest_release }}
+
+# List all available releases
+[group('release')]
+releases:
+    uv run overturemaps releases list
+
+# Build the package
+[group('build')]
+build:
+    uv build

--- a/overturemaps/cli.py
+++ b/overturemaps/cli.py
@@ -16,6 +16,7 @@ import click
 import orjson
 import pyarrow.parquet as pq
 import shapely
+from tqdm import tqdm
 
 from .core import (
     get_all_overture_types,
@@ -23,6 +24,7 @@ from .core import (
     get_latest_release,
     record_batch_reader,
     record_batch_reader_from_gers,
+    count_rows,
 )
 from .releases import list_releases, release_exists
 
@@ -165,6 +167,8 @@ def download(
     if output is None:
         output = sys.stdout
 
+    total = count_rows(type_, bbox, release, connect_timeout, request_timeout, stac)
+
     reader = record_batch_reader(
         type_, bbox, release, connect_timeout, request_timeout, stac
     )
@@ -173,7 +177,7 @@ def download(
         return
 
     with get_writer(output_format, output, schema=reader.schema) as writer:
-        copy(reader, writer)
+        copy(reader, writer, total=total)
 
 
 @cli.command()
@@ -239,14 +243,16 @@ def gers(gers_id, output_format, output, connect_timeout, request_timeout):
         copy(reader, writer)
 
 
-def copy(reader, writer):
-    while True:
-        try:
-            batch = reader.read_next_batch()
-        except StopIteration:
-            break
-        if batch.num_rows > 0:
-            writer.write_batch(batch)
+def copy(reader, writer, total=None):
+    with tqdm(total=total, unit="rows", desc="Downloading", file=sys.stderr) as bar:
+        while True:
+            try:
+                batch = reader.read_next_batch()
+            except StopIteration:
+                break
+            if batch.num_rows > 0:
+                writer.write_batch(batch)
+                bar.update(batch.num_rows)
 
 
 class BaseGeoJSONWriter:

--- a/overturemaps/cli.py
+++ b/overturemaps/cli.py
@@ -27,7 +27,6 @@ from .core import (
     record_batch_reader,
     record_batch_reader_from_gers,
     type_theme_map,
-    count_rows,
 )
 from .models import Backend, BBox, PipelineState
 from .releases import list_releases, release_exists
@@ -239,8 +238,6 @@ def download(
     else:
         output_file = output
 
-    total = count_rows(type_, bbox, release, connect_timeout, request_timeout, stac)
-
     reader = record_batch_reader(
         type_, bbox, release, connect_timeout, request_timeout, stac
     )
@@ -249,7 +246,7 @@ def download(
         return
 
     with get_writer(output_format, output_file, schema=reader.schema) as writer:
-        copy(reader, writer, total=total)
+        copy(reader, writer)
 
     # Save state file if output was written to a file
     if output is not None:
@@ -348,8 +345,8 @@ def gers(ctx, gers_id, output_format, output, connect_timeout, request_timeout):
         copy(reader, writer)
 
 
-def copy(reader, writer, total=None):
-    with tqdm(total=total, unit="rows", desc="Downloading", file=sys.stderr) as bar:
+def copy(reader, writer):
+    with tqdm(total=None, unit=" rows", desc="Downloading", file=sys.stderr) as bar:
         while True:
             try:
                 batch = reader.read_next_batch()

--- a/overturemaps/core.py
+++ b/overturemaps/core.py
@@ -162,41 +162,25 @@ def _get_files_from_stac(
         return None
 
 
-def _create_s3_record_batch_reader(
-    path,
+def _record_batch_reader_from_dataset(
+    dataset: ds.Dataset,
     filter_expr=None,
-    connect_timeout=None,
-    request_timeout=None,
 ) -> Optional[pa.RecordBatchReader]:
     """
-    Create a RecordBatchReader from S3 path(s) with optional filtering.
+    Create a RecordBatchReader from an S3 dataset with optional filtering.
 
     Parameters
     ----------
-    path: str or list of str
-        S3 path(s) in the format "bucket/key" (without s3:// prefix)
+    dataset: pyarrow dataset
+        Dataset to read from
     filter_expr: pyarrow expression, optional
         Filter to apply when reading the dataset
-    connect_timeout: int, optional
-        Connection timeout in seconds
-    request_timeout: int, optional
-        Request timeout in seconds
 
     Returns
     -------
     RecordBatchReader with the feature data, or None if error occurs
     """
     try:
-        dataset = ds.dataset(
-            path,
-            filesystem=fs.S3FileSystem(
-                anonymous=True,
-                region="us-west-2",
-                connect_timeout=connect_timeout,
-                request_timeout=request_timeout,
-            ),
-        )
-
         batches = dataset.to_batches(
             filter=filter_expr,
             use_threads=True,
@@ -208,27 +192,26 @@ def _create_s3_record_batch_reader(
         non_empty_batches = (b for b in batches if b.num_rows > 0)
 
         geoarrow_schema = geoarrow_schema_adapter(dataset.schema)
-        reader = pa.RecordBatchReader.from_batches(geoarrow_schema, non_empty_batches)
-
-        return reader
+        return pa.RecordBatchReader.from_batches(geoarrow_schema, non_empty_batches)
 
     except Exception as e:
-        print(f"Error reading data from path {path}: {e}")
+        print(f"Error reading dataset: {e}")
         return None
 
 
-def record_batch_reader(
+def _prepare_query(
     overture_type,
     bbox=None,
     release=None,
     connect_timeout=None,
     request_timeout=None,
     stac=False,
-) -> Optional[pa.RecordBatchReader]:
+) -> Tuple[ds.Dataset, Optional[pc.Expression]]:
     """
-    Return a pyarrow RecordBatchReader for the desired bounding box and s3 path
-    """
+    Resolve the S3 dataset and filter expression for a given query.
 
+    Returns the dataset and filter expression ready for counting or streaming.
+    """
     if release is None:
         release = get_latest_release()
     path = _dataset_path(overture_type, release)
@@ -250,12 +233,47 @@ def record_batch_reader(
     else:
         filter_expr = None
 
-    return _create_s3_record_batch_reader(
+    dataset = ds.dataset(
         intersecting_files if intersecting_files else path,
-        filter_expr=filter_expr,
-        connect_timeout=connect_timeout,
-        request_timeout=request_timeout,
+        filesystem=fs.S3FileSystem(
+            anonymous=True,
+            region="us-west-2",
+            connect_timeout=connect_timeout,
+            request_timeout=request_timeout,
+        ),
     )
+
+    return dataset, filter_expr
+
+
+def count_rows(
+    overture_type,
+    bbox=None,
+    release=None,
+    connect_timeout=None,
+    request_timeout=None,
+    stac=False,
+) -> int:
+    """Return the number of rows matching the given parameters."""
+    dataset, filter_expr = _prepare_query(
+        overture_type, bbox, release, connect_timeout, request_timeout, stac
+    )
+    return dataset.count_rows(filter=filter_expr)
+
+
+def record_batch_reader(
+    overture_type,
+    bbox=None,
+    release=None,
+    connect_timeout=None,
+    request_timeout=None,
+    stac=False,
+) -> Optional[pa.RecordBatchReader]:
+    """Return a pyarrow RecordBatchReader for the desired bounding box and s3 path, or None on error."""
+    dataset, filter_expr = _prepare_query(
+        overture_type, bbox, release, connect_timeout, request_timeout, stac
+    )
+    return _record_batch_reader_from_dataset(dataset, filter_expr=filter_expr)
 
 
 def geodataframe(
@@ -567,9 +585,13 @@ def record_batch_reader_from_gers(
         )
         filter_expr = filter_expr & bbox_filter
 
-    return _create_s3_record_batch_reader(
+    dataset = ds.dataset(
         filepath,
-        filter_expr=filter_expr,
-        connect_timeout=connect_timeout,
-        request_timeout=request_timeout,
+        filesystem=fs.S3FileSystem(
+            anonymous=True,
+            region="us-west-2",
+            connect_timeout=connect_timeout,
+            request_timeout=request_timeout,
+        ),
     )
+    return _record_batch_reader_from_dataset(dataset, filter_expr=filter_expr)

--- a/overturemaps/core.py
+++ b/overturemaps/core.py
@@ -287,6 +287,7 @@ def count_rows(
     return dataset.count_rows(filter=filter_expr)
 
 
+
 def record_batch_reader(
     overture_type,
     bbox=None,

--- a/overturemaps/core.py
+++ b/overturemaps/core.py
@@ -1,5 +1,6 @@
 import io
 import json
+import sys
 from typing import List, Optional, Tuple
 from urllib.request import urlopen
 
@@ -231,11 +232,12 @@ def _prepare_query(
     connect_timeout=None,
     request_timeout=None,
     stac=False,
-) -> Tuple[ds.Dataset, Optional[pc.Expression]]:
+) -> Optional[Tuple[ds.Dataset, Optional[pc.Expression]]]:
     """
     Resolve the S3 dataset and filter expression for a given query.
 
-    Returns the dataset and filter expression ready for counting or streaming.
+    Returns the dataset and filter expression ready for counting or streaming,
+    or None if STAC reports no files intersect the bbox.
     """
     if release is None:
         release = get_latest_release()
@@ -247,6 +249,8 @@ def _prepare_query(
         intersecting_files = _get_files_from_stac(
             type_theme_map[overture_type], overture_type, bbox_obj, release
         )
+        if intersecting_files is not None and len(intersecting_files) == 0:
+            return None
 
     if bbox_obj:
         xmin, ymin, xmax, ymax = bbox_obj.as_tuple()
@@ -260,7 +264,7 @@ def _prepare_query(
         filter_expr = None
 
     dataset = ds.dataset(
-        intersecting_files if intersecting_files else path,
+        intersecting_files if intersecting_files is not None else path,
         filesystem=fs.S3FileSystem(
             anonymous=True,
             region="us-west-2",
@@ -281,9 +285,12 @@ def count_rows(
     stac=False,
 ) -> int:
     """Return the number of rows matching the given parameters."""
-    dataset, filter_expr = _prepare_query(
+    result = _prepare_query(
         overture_type, bbox, release, connect_timeout, request_timeout, stac
     )
+    if result is None:
+        return 0
+    dataset, filter_expr = result
     return dataset.count_rows(filter=filter_expr)
 
 
@@ -297,9 +304,12 @@ def record_batch_reader(
     stac=False,
 ) -> Optional[pa.RecordBatchReader]:
     """Return a pyarrow RecordBatchReader for the desired bounding box and s3 path, or None on error."""
-    dataset, filter_expr = _prepare_query(
+    result = _prepare_query(
         overture_type, bbox, release, connect_timeout, request_timeout, stac
     )
+    if result is None:
+        return None
+    dataset, filter_expr = result
     return _record_batch_reader_from_dataset(dataset, filter_expr=filter_expr)
 
 
@@ -612,13 +622,17 @@ def record_batch_reader_from_gers(
         )
         filter_expr = filter_expr & bbox_filter
 
-    dataset = ds.dataset(
-        filepath,
-        filesystem=fs.S3FileSystem(
-            anonymous=True,
-            region="us-west-2",
-            connect_timeout=connect_timeout,
-            request_timeout=request_timeout,
-        ),
-    )
+    try:
+        dataset = ds.dataset(
+            filepath,
+            filesystem=fs.S3FileSystem(
+                anonymous=True,
+                region="us-west-2",
+                connect_timeout=connect_timeout,
+                request_timeout=request_timeout,
+            ),
+        )
+    except Exception as e:
+        print(f"Error opening dataset for GERS ID '{gers_id}': {e}", file=sys.stderr)
+        return None
     return _record_batch_reader_from_dataset(dataset, filter_expr=filter_expr)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     # (4) it's already a transitive dependency of geopandas when that optional extra is installed.
     # Keeping it signals that this package is ready for data science workflows.
     "numpy>=1.26.4",
+    "tqdm>=4.67.3",
 ]
 
 [project.urls]

--- a/tests/test_cli_download.py
+++ b/tests/test_cli_download.py
@@ -30,6 +30,7 @@ def test_download_saves_absolute_output_path(monkeypatch):
     captured = {}
 
     monkeypatch.setattr("overturemaps.cli.get_latest_release", lambda: "2024-11-13.0")
+    monkeypatch.setattr("overturemaps.cli.count_rows", lambda *args, **kwargs: 0)
     monkeypatch.setattr(
         "overturemaps.cli.record_batch_reader", lambda *args, **kwargs: _DummyReader()
     )
@@ -142,6 +143,7 @@ def test_bbox_area_sq_deg():
 def test_download_warns_on_large_bbox(monkeypatch):
     """download should warn when bbox is very large."""
     monkeypatch.setattr("overturemaps.cli.get_latest_release", lambda: "2024-11-13.0")
+    monkeypatch.setattr("overturemaps.cli.count_rows", lambda *args, **kwargs: 0)
     monkeypatch.setattr(
         "overturemaps.cli.record_batch_reader", lambda *args, **kwargs: _DummyReader()
     )
@@ -172,6 +174,7 @@ def test_download_warns_on_large_bbox(monkeypatch):
 def test_download_warns_on_no_bbox(monkeypatch):
     """download should warn when no bbox is provided."""
     monkeypatch.setattr("overturemaps.cli.get_latest_release", lambda: "2024-11-13.0")
+    monkeypatch.setattr("overturemaps.cli.count_rows", lambda *args, **kwargs: 0)
     monkeypatch.setattr(
         "overturemaps.cli.record_batch_reader", lambda *args, **kwargs: _DummyReader()
     )
@@ -200,6 +203,7 @@ def test_download_warns_on_no_bbox(monkeypatch):
 def test_download_no_warning_on_small_bbox(monkeypatch):
     """download should not warn when bbox is small."""
     monkeypatch.setattr("overturemaps.cli.get_latest_release", lambda: "2024-11-13.0")
+    monkeypatch.setattr("overturemaps.cli.count_rows", lambda *args, **kwargs: 0)
     monkeypatch.setattr(
         "overturemaps.cli.record_batch_reader", lambda *args, **kwargs: _DummyReader()
     )

--- a/tests/test_cli_download.py
+++ b/tests/test_cli_download.py
@@ -30,7 +30,7 @@ def test_download_saves_absolute_output_path(monkeypatch):
     captured = {}
 
     monkeypatch.setattr("overturemaps.cli.get_latest_release", lambda: "2024-11-13.0")
-    monkeypatch.setattr("overturemaps.cli.count_rows", lambda *args, **kwargs: 0)
+
     monkeypatch.setattr(
         "overturemaps.cli.record_batch_reader", lambda *args, **kwargs: _DummyReader()
     )
@@ -143,7 +143,7 @@ def test_bbox_area_sq_deg():
 def test_download_warns_on_large_bbox(monkeypatch):
     """download should warn when bbox is very large."""
     monkeypatch.setattr("overturemaps.cli.get_latest_release", lambda: "2024-11-13.0")
-    monkeypatch.setattr("overturemaps.cli.count_rows", lambda *args, **kwargs: 0)
+
     monkeypatch.setattr(
         "overturemaps.cli.record_batch_reader", lambda *args, **kwargs: _DummyReader()
     )
@@ -174,7 +174,7 @@ def test_download_warns_on_large_bbox(monkeypatch):
 def test_download_warns_on_no_bbox(monkeypatch):
     """download should warn when no bbox is provided."""
     monkeypatch.setattr("overturemaps.cli.get_latest_release", lambda: "2024-11-13.0")
-    monkeypatch.setattr("overturemaps.cli.count_rows", lambda *args, **kwargs: 0)
+
     monkeypatch.setattr(
         "overturemaps.cli.record_batch_reader", lambda *args, **kwargs: _DummyReader()
     )
@@ -203,7 +203,7 @@ def test_download_warns_on_no_bbox(monkeypatch):
 def test_download_no_warning_on_small_bbox(monkeypatch):
     """download should not warn when bbox is small."""
     monkeypatch.setattr("overturemaps.cli.get_latest_release", lambda: "2024-11-13.0")
-    monkeypatch.setattr("overturemaps.cli.count_rows", lambda *args, **kwargs: 0)
+
     monkeypatch.setattr(
         "overturemaps.cli.record_batch_reader", lambda *args, **kwargs: _DummyReader()
     )

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -1,0 +1,123 @@
+"""Tests for the copy() function and its background count_rows thread."""
+
+import threading
+import time
+
+import pyarrow as pa
+import pytest
+
+from overturemaps.cli import copy
+
+
+class _FakeBatch:
+    def __init__(self, num_rows):
+        self.num_rows = num_rows
+
+
+class _FakeReader:
+    """Yields batches with an optional per-batch delay."""
+
+    def __init__(self, batches, delay=0.0):
+        self._batches = iter(batches)
+        self._delay = delay
+
+    def read_next_batch(self):
+        if self._delay:
+            time.sleep(self._delay)
+        try:
+            return next(self._batches)
+        except StopIteration:
+            raise StopIteration
+
+
+class _FakeWriter:
+    def __init__(self):
+        self.batches = []
+
+    def write_batch(self, batch):
+        self.batches.append(batch)
+
+
+def _capture_bar(monkeypatch):
+    """Patch tqdm so we can inspect the bar instance after copy() returns."""
+    import overturemaps.cli as cli_module
+
+    bars = []
+    real_tqdm = cli_module.tqdm
+
+    class CapturingTqdm(real_tqdm):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            bars.append(self)
+
+    monkeypatch.setattr(cli_module, "tqdm", CapturingTqdm)
+    return bars
+
+
+def test_copy_sets_total_when_count_resolves_first(monkeypatch):
+    """bar.total is updated when count_rows_fn resolves before the download ends."""
+    bars = _capture_bar(monkeypatch)
+
+    # Slow reader: each batch takes 50 ms → 3 batches = ~150 ms total
+    reader = _FakeReader([_FakeBatch(10)] * 3, delay=0.05)
+    writer = _FakeWriter()
+
+    # Fast count: resolves almost immediately
+    def fast_count():
+        return 30
+
+    copy(reader, writer, count_rows_fn=fast_count)
+
+    assert bars[0].total == 30
+
+
+def test_copy_total_stays_none_when_download_finishes_first(monkeypatch):
+    """bar.total stays None when the download finishes before count_rows_fn resolves."""
+    bars = _capture_bar(monkeypatch)
+
+    # Fast reader: no delay
+    reader = _FakeReader([_FakeBatch(10)] * 3)
+    writer = _FakeWriter()
+
+    resolved = threading.Event()
+
+    # Slow count: takes 200 ms — download will be done by then
+    def slow_count():
+        time.sleep(0.2)
+        resolved.set()
+        return 30
+
+    copy(reader, writer, count_rows_fn=slow_count)
+
+    # Give the background thread time to finish so we're not racing
+    resolved.wait(timeout=1.0)
+    assert bars[0].total is None
+
+
+def test_copy_survives_count_rows_fn_exception(monkeypatch):
+    """Download completes normally even if count_rows_fn raises."""
+    bars = _capture_bar(monkeypatch)
+
+    reader = _FakeReader([_FakeBatch(5)] * 2)
+    writer = _FakeWriter()
+
+    def broken_count():
+        raise RuntimeError("S3 unavailable")
+
+    copy(reader, writer, count_rows_fn=broken_count)
+
+    assert len(writer.batches) == 2
+    assert bars[0].total is None
+
+
+def test_copy_without_count_rows_fn(monkeypatch):
+    """copy() works fine with no count_rows_fn — no thread is started."""
+    bars = _capture_bar(monkeypatch)
+
+    reader = _FakeReader([_FakeBatch(7)])
+    writer = _FakeWriter()
+
+    copy(reader, writer)
+
+    assert len(writer.batches) == 1
+    assert bars[0].total is None

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -1,10 +1,4 @@
-"""Tests for the copy() function and its background count_rows thread."""
-
-import threading
-import time
-
-import pyarrow as pa
-import pytest
+"""Tests for the copy() function."""
 
 from overturemaps.cli import copy
 
@@ -15,15 +9,10 @@ class _FakeBatch:
 
 
 class _FakeReader:
-    """Yields batches with an optional per-batch delay."""
-
-    def __init__(self, batches, delay=0.0):
+    def __init__(self, batches):
         self._batches = iter(batches)
-        self._delay = delay
 
     def read_next_batch(self):
-        if self._delay:
-            time.sleep(self._delay)
         try:
             return next(self._batches)
         except StopIteration:
@@ -38,86 +27,28 @@ class _FakeWriter:
         self.batches.append(batch)
 
 
-def _capture_bar(monkeypatch):
-    """Patch tqdm so we can inspect the bar instance after copy() returns."""
-    import overturemaps.cli as cli_module
-
-    bars = []
-    real_tqdm = cli_module.tqdm
-
-    class CapturingTqdm(real_tqdm):
-        def __init__(self, *args, **kwargs):
-            super().__init__(*args, **kwargs)
-            bars.append(self)
-
-    monkeypatch.setattr(cli_module, "tqdm", CapturingTqdm)
-    return bars
-
-
-def test_copy_sets_total_when_count_resolves_first(monkeypatch):
-    """bar.total is updated when count_rows_fn resolves before the download ends."""
-    bars = _capture_bar(monkeypatch)
-
-    # Slow reader: each batch takes 50 ms → 3 batches = ~150 ms total
-    reader = _FakeReader([_FakeBatch(10)] * 3, delay=0.05)
+def test_copy_writes_all_batches():
+    reader = _FakeReader([_FakeBatch(10), _FakeBatch(20), _FakeBatch(5)])
     writer = _FakeWriter()
 
-    # Fast count: resolves almost immediately
-    def fast_count():
-        return 30
+    copy(reader, writer)
 
-    copy(reader, writer, count_rows_fn=fast_count)
-
-    assert bars[0].total == 30
+    assert len(writer.batches) == 3
 
 
-def test_copy_total_stays_none_when_download_finishes_first(monkeypatch):
-    """bar.total stays None when the download finishes before count_rows_fn resolves."""
-    bars = _capture_bar(monkeypatch)
-
-    # Fast reader: no delay
-    reader = _FakeReader([_FakeBatch(10)] * 3)
-    writer = _FakeWriter()
-
-    resolved = threading.Event()
-
-    # Slow count: takes 200 ms — download will be done by then
-    def slow_count():
-        time.sleep(0.2)
-        resolved.set()
-        return 30
-
-    copy(reader, writer, count_rows_fn=slow_count)
-
-    # Give the background thread time to finish so we're not racing
-    resolved.wait(timeout=1.0)
-    assert bars[0].total is None
-
-
-def test_copy_survives_count_rows_fn_exception(monkeypatch):
-    """Download completes normally even if count_rows_fn raises."""
-    bars = _capture_bar(monkeypatch)
-
-    reader = _FakeReader([_FakeBatch(5)] * 2)
-    writer = _FakeWriter()
-
-    def broken_count():
-        raise RuntimeError("S3 unavailable")
-
-    copy(reader, writer, count_rows_fn=broken_count)
-
-    assert len(writer.batches) == 2
-    assert bars[0].total is None
-
-
-def test_copy_without_count_rows_fn(monkeypatch):
-    """copy() works fine with no count_rows_fn — no thread is started."""
-    bars = _capture_bar(monkeypatch)
-
-    reader = _FakeReader([_FakeBatch(7)])
+def test_copy_skips_empty_batches():
+    reader = _FakeReader([_FakeBatch(0), _FakeBatch(10), _FakeBatch(0)])
     writer = _FakeWriter()
 
     copy(reader, writer)
 
     assert len(writer.batches) == 1
-    assert bars[0].total is None
+
+
+def test_copy_empty_reader():
+    reader = _FakeReader([])
+    writer = _FakeWriter()
+
+    copy(reader, writer)
+
+    assert len(writer.batches) == 0

--- a/uv.lock
+++ b/uv.lock
@@ -308,7 +308,7 @@ wheels = [
 
 [[package]]
 name = "overturemaps"
-version = "0.19.0"
+version = "0.20.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },

--- a/uv.lock
+++ b/uv.lock
@@ -317,6 +317,7 @@ dependencies = [
     { name = "orjson" },
     { name = "pyarrow" },
     { name = "shapely" },
+    { name = "tqdm" },
 ]
 
 [package.optional-dependencies]
@@ -339,6 +340,7 @@ requires-dist = [
     { name = "orjson", specifier = ">=3.9.0" },
     { name = "pyarrow", specifier = ">=15.0.2" },
     { name = "shapely", specifier = ">=2.1.0" },
+    { name = "tqdm", specifier = ">=4.67.3" },
 ]
 provides-extras = ["geopandas"]
 
@@ -868,6 +870,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/de/69/9aa0c6a505c2f80e519b43764f8b4ba93b5a0bbd2d9a9de6e2b24271b9a5/tomli-2.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:2add28aacc7425117ff6364fe9e06a183bb0251b03f986df0e78e974047571fd", size = 120504, upload-time = "2026-01-11T11:22:35.764Z" },
     { url = "https://files.pythonhosted.org/packages/b3/9f/f1668c281c58cfae01482f7114a4b88d345e4c140386241a1a24dcc9e7bc/tomli-2.4.0-cp314-cp314t-win_arm64.whl", hash = "sha256:2b1e3b80e1d5e52e40e9b924ec43d81570f0e7d09d11081b797bc4692765a3d4", size = 99561, upload-time = "2026-01-11T11:22:36.624Z" },
     { url = "https://files.pythonhosted.org/packages/23/d1/136eb2cb77520a31e1f64cbae9d33ec6df0d78bdf4160398e86eec8a8754/tomli-2.4.0-py3-none-any.whl", hash = "sha256:1f776e7d669ebceb01dee46484485f43a4048746235e683bcdffacdf1fb4785a", size = 14477, upload-time = "2026-01-11T11:22:37.446Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.67.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
> **NOTE:** This PR depends on [#95](https://github.com/OvertureMaps/overturemaps-py/pull/95) and cannot be merged until that one is closed.

## Changes

- [x] Refactor `core.py`: new functions `_prepare_query` and `count_rows`
- [x] Add `tqdm` progress bar in the `download` command
- [x] Add `bench_count_rows.py` network benchmark

## Benchmarking

`tqdm`'s progress bar needs to know the row count ahead of time, which adds some extra time. I added benchmarks to test the new `count_rows` function.

| Bbox | Rows | Mean | Min | Max |
|---|---|---|---|---|
| Small | 924 | 8.7s | 7.98s | 9.13s |
| Larger | 217202 | 9.4s | 7.08s | 12.05s |

The main point here is that getting the row count adds just under 10s extra per query. The benchmarking shows that this scales well — the time won't increase as the bbox gets larger. The bottleneck is a fixed download of `collections.parquet` from the STAC endpoint (~8MB), which is needed to identify which Parquet files intersect the bbox. The actual row count is then read from the Parquet file footers, which is fast. `count_rows` was tested with a small area and a full city.

Closes https://github.com/OvertureMaps/overturemaps-py/issues/16