### PR TITLE
[DOCS] Add homebrew installation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,7 @@ The package is published to [PyPI](https://pypi.org/project/overturemaps/) via t
 2. Commit and merge to `main`.
 3. Create a GitHub Release (tag + title + notes). Publishing the release triggers the workflow automatically.
 4. The workflow builds the package and publishes to PyPI in the [`pypi` GitHub environment](https://github.com/OvertureMaps/overturemaps-py/deployments).
+5. After the release, open a PR in [homebrew-core](https://github.com/Homebrew/homebrew-core) to bump the formula version.
 
 ### Dry-run / Test PyPI
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ The package is published to [PyPI](https://pypi.org/project/overturemaps/) via t
 2. Commit and merge to `main`.
 3. Create a GitHub Release (tag + title + notes). Publishing the release triggers the workflow automatically.
 4. The workflow builds the package and publishes to PyPI in the [`pypi` GitHub environment](https://github.com/OvertureMaps/overturemaps-py/deployments).
-5. After the release, open a PR in [homebrew-core](https://github.com/Homebrew/homebrew-core) to bump the formula version.
+5. After the release, [open a PR](https://docs.brew.sh/How-To-Open-a-Homebrew-Pull-Request) in [homebrew-core](https://github.com/Homebrew/homebrew-core) to bump the formula version.
 
 ### Dry-run / Test PyPI
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,13 @@ Command-line options:
 
 ## Installation
 
-To install overturemaps from [PyPi](https://pypi.org/project/overturemaps/) using pip
+overturemaps is available via [Homebrew](https://brew.sh/):
+
+```bash
+brew install overturemaps
+```
+
+To install overturemaps from [PyPi](https://pypi.org/project/overturemaps/) using pip:
 
 ```bash
 pip install overturemaps


### PR DESCRIPTION
Add Homebrew installation option to README. See homebrew merged [PR](https://github.com/Homebrew/homebrew-core/pull/276108).

Closes https://github.com/OvertureMaps/overturemaps-py/issues/7