### PR TITLE
[FEATURE] Add binary builds + QoL upgrades

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -1,0 +1,101 @@
+---
+# Builds standalone binaries for Linux, macOS (arm64 + x86_64), and Windows.
+# On release: attaches binaries directly to the GitHub Release as assets.
+# On workflow_dispatch: uploads binaries as workflow artifacts for inspection.
+name: Build Binaries
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read # default; job overrides to write for release asset upload
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write # required to upload release assets via gh release upload
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: linux-x86_64
+            ext: ""
+          - os: macos-latest
+            target: macos-arm64
+            ext: ""
+          - os: macos-13
+            target: macos-x86_64
+            ext: ""
+          - os: windows-latest
+            target: windows-x86_64
+            ext: ".exe"
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --group binary
+
+      - name: Get version
+        id: version
+        shell: bash
+        run: |
+          VERSION=$(uv run python -c "from importlib.metadata import version; print(version('overturemaps'))")
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Build binary
+        run: >-
+          uv run pyinstaller
+          --onefile
+          --name overturemaps
+          --collect-all pyarrow
+          --collect-all shapely
+          --collect-data pyfiglet
+          overturemaps/__main__.py
+
+      - name: Rename binary
+        shell: bash
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          TARGET: ${{ matrix.target }}
+          EXT: ${{ matrix.ext }}
+        run: |
+          SRC="dist/overturemaps${EXT}"
+          DST="dist/overturemaps-${VERSION}-${TARGET}${EXT}"
+          mv "$SRC" "$DST"
+          echo "BINARY_PATH=${DST}" >> "$GITHUB_ENV"
+
+      - name: Smoke test binary
+        shell: bash
+        run: |
+          "$BINARY_PATH" --help
+
+      - name: Upload to release
+        if: github.event_name == 'release'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+        run: gh release upload "$TAG" "$BINARY_PATH" --clobber
+
+      - name: Upload artifact (dry run)
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: overturemaps-${{ matrix.target }}
+          path: ${{ env.BINARY_PATH }}
+          if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -77,8 +77,9 @@ from overturemaps import record_batch_reader
 bbox = (-71.068, 42.353, -71.058, 42.363)  # xmin, ymin, xmax, ymax
 reader = record_batch_reader("building", bbox=bbox)
 
-table = reader.read_all()
-print(table.schema)
+if reader is not None:
+    table = reader.read_all()
+    print(table.schema)
 ```
 
 #### GeoDataFrame (geopandas)

--- a/README.md
+++ b/README.md
@@ -61,6 +61,57 @@ Command-line options:
 - `--connect_timeout` (optional): Socket connection timeout, in seconds. If omitted, the AWS SDK default value is used (typically 1 second).
 - `--request_timeout` (optional): Socket read timeouts on Windows and macOS, in seconds. If omitted, the AWS SDK default value is used (typically 3 seconds). This option is ignored on non-Windows, non-macOS systems.
 
+## Python API
+
+`overturemaps` is also a Python library. Import directly from `overturemaps` to query Overture data
+without using the CLI.
+
+#### Arrow / pyarrow
+
+`record_batch_reader` returns a `pyarrow.RecordBatchReader` — a streaming cursor over the data.
+This is the lowest-level entry point and works with any Arrow-compatible tool.
+
+```python
+from overturemaps import record_batch_reader
+
+bbox = (-71.068, 42.353, -71.058, 42.363)  # xmin, ymin, xmax, ymax
+reader = record_batch_reader("building", bbox=bbox)
+
+table = reader.read_all()
+print(table.schema)
+```
+
+#### GeoDataFrame (geopandas)
+
+`geodataframe` loads data directly into a `geopandas.GeoDataFrame`. Requires `geopandas` to be
+installed (`pip install overturemaps[geopandas]` or `pip install geopandas`).
+
+```python
+from overturemaps import geodataframe
+
+bbox = (-71.068, 42.353, -71.058, 42.363)
+gdf = geodataframe("building", bbox=bbox)
+print(gdf.head())
+```
+
+#### Writing to a file format
+
+Use `get_writer` and `copy` from `overturemaps.writers` to write data to GeoJSON, GeoJSONSeq, or
+GeoParquet without the CLI:
+
+```python
+from overturemaps import record_batch_reader
+from overturemaps.writers import copy, get_writer
+
+bbox = (-71.068, 42.353, -71.058, 42.363)
+reader = record_batch_reader("building", bbox=bbox)
+
+with get_writer("geojson", "boston.geojson", schema=reader.schema) as writer:
+    copy(reader, writer)
+```
+
+Supported format strings: `"geojson"`, `"geojsonseq"`, `"geoparquet"`.
+
 ## Installation
 
 overturemaps is available via [Homebrew](https://brew.sh/):

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # overturemaps-py — Project Specification
 
-**Version**: 0.20.0
+**Version**: 0.21.0
 **Python**: ≥ 3.10
 **License**: MIT
 **Maintainers**: Adam Lastowka, Dana Bauer (@overturemaps.org)

--- a/SPEC.md
+++ b/SPEC.md
@@ -169,7 +169,7 @@ def geodataframe(
 ) -> GeoDataFrame
 ```
 
-Requires `geopandas` extra (`pip install overturemaps[geopandas]`). Raises `ImportError` with install hint if `geopandas` not present.
+Requires the `geopandas` extra (`pip install overturemaps[geopandas]`). Raises `ImportError("geopandas is required to use this function")` if `geopandas` is not installed.
 
 ### 4.4 `geoarrow_schema_adapter`
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,0 +1,572 @@
+# overturemaps-py — Project Specification
+
+**Version**: 0.20.0
+**Python**: ≥ 3.10
+**License**: MIT
+**Maintainers**: Adam Lastowka, Dana Bauer (@overturemaps.org)
+
+---
+
+## 1. Purpose and Scope
+
+`overturemaps` is the official Python CLI and library for the Overture Maps Foundation. It provides:
+
+1. **Direct S3 streaming**: Download Overture feature data (buildings, places, roads, etc.) from S3 without intermediate staging.
+2. **Spatial filtering**: Bbox-filtered queries using per-row Parquet metadata to minimize bytes transferred.
+3. **Multiple output formats**: GeoJSON, GeoJSONSeq, GeoParquet.
+4. **GERS lookup**: Fetch a single feature by its Overture Global Entity Reference System (GERS) UUID.
+5. **Changelog queries**: Inspect what changed between releases for a given area.
+6. **State tracking**: Sidecar `.state` files to detect when local data is stale.
+
+Everything reads from a single public, anonymous-access S3 bucket (`overturemaps-us-west-2`). No authentication required. No data is written to S3.
+
+---
+
+## 2. Architecture
+
+### 2.1 Layered Design
+
+```
+CLI (cli.py)
+  └── Core data access (core.py)
+        ├── STAC catalog (stac.overturemaps.org)
+        ├── S3 dataset (pyarrow S3FileSystem, anonymous)
+        └── GERS registry (binary search over manifest)
+
+Writers (writers.py)           ← output format writers + copy() pipeline
+Releases (releases.py)       ← thin wrapper over core
+Changelog (changelog.py)     ← parallel to core, same S3 bucket
+State (state.py)             ← sidecar JSON files
+Models (models.py)           ← pure data classes, no I/O
+```
+
+### 2.2 Data Access Patterns
+
+**Default path (STAC-accelerated)**:
+1. Fetch `https://stac.overturemaps.org/catalog.json` (in-process cached).
+2. Download `/{release}/collections.parquet` (column-pruned, spatially filtered).
+3. Extract the list of Parquet file paths that intersect the query bbox.
+4. Open those files as a `pyarrow.dataset.Dataset` with row-level bbox predicate pushdown.
+5. Stream `RecordBatch` objects through writer.
+
+**Fallback path (no STAC)**:
+- `--no-stac` flag skips step 2–3; opens the full S3 partition directly.
+
+**GERS path**:
+1. Fetch STAC catalog → registry manifest (`[filename, max_id]` sorted list).
+2. Binary-search manifest to find the shard file.
+3. Open shard; apply `filters=[("id", "=", gers_id)]`.
+
+**Changelog path**:
+1. Attempt STAC-based file list (future capability; currently always falls back).
+2. Open S3 changelog partition directly with hive partitioning.
+3. Apply spatial bbox filter and `change_type != "unchanged"`.
+
+### 2.3 S3 Path Conventions
+
+| Data | S3 Path |
+|---|---|
+| Feature data | `overturemaps-us-west-2/release/{release}/theme={theme}/type={type}/` |
+| GERS registry | `overturemaps-us-west-2/registry/{filename}` |
+| Changelog | `overturemaps-us-west-2/changelog/{release}/theme={theme}/type={type}/` |
+
+---
+
+## 3. Data Model
+
+### 3.1 Feature Types and Themes
+
+Exactly 15 feature types across 5 themes:
+
+| Theme | Types |
+|---|---|
+| `addresses` | `address` |
+| `base` | `bathymetry`, `infrastructure`, `land`, `land_cover`, `land_use`, `water` |
+| `buildings` | `building`, `building_part` |
+| `divisions` | `division`, `division_area`, `division_boundary` |
+| `places` | `place` |
+| `transportation` | `connector`, `segment` |
+
+### 3.2 `BBox` Dataclass
+
+Fields: `xmin: float`, `ymin: float`, `xmax: float`, `ymax: float`
+
+**Validation invariants** (enforced at CLI boundary):
+- `xmin`, `xmax` ∈ [-180, 180]
+- `ymin`, `ymax` ∈ [-90, 90]
+- `xmin ≤ xmax`
+- `ymin ≤ ymax`
+
+Serialization: `as_tuple()`, `as_dict()`, `from_dict()`.
+
+### 3.3 `Backend` StrEnum
+
+Values: `geojson`, `geojsonseq`, `geoparquet`.
+
+Python 3.10 compatible (StrEnum added in 3.11; shim required).
+
+### 3.4 `PipelineState` Dataclass
+
+Persisted as JSON sidecar beside output files.
+
+| Field | Type | Notes |
+|---|---|---|
+| `last_release` | `str` | e.g. `"2025-04-23.0"` |
+| `last_run` | `str` | ISO 8601 datetime |
+| `theme` | `str` | Overture theme name |
+| `type` | `str` | Overture feature type |
+| `bbox` | `BBox \| None` | `None` = global download |
+| `backend` | `Backend` | Output format |
+| `output` | `str` | **Absolute** output file path |
+
+`output` MUST be stored as an absolute path (resolved at write time via `Path.resolve()`).
+
+---
+
+## 4. Public Python API
+
+Exported from `overturemaps.__init__`:
+
+```python
+from overturemaps import record_batch_reader, get_all_overture_types
+```
+
+### 4.1 `record_batch_reader`
+
+```python
+def record_batch_reader(
+    type: str,
+    bbox: BBox | tuple | list | None = None,
+    release: str | None = None,
+    *,
+    connect_timeout: int | None = None,
+    request_timeout: int | None = None,
+    stac: bool = True,
+) -> pyarrow.RecordBatchReader | None
+```
+
+- Returns a streaming `RecordBatchReader`; returns `None` if no data matches.
+- `bbox=None` queries globally (large data warning applies at CLI layer, not here).
+- `release=None` resolves to latest release.
+- When `stac=True`, uses STAC spatial index to minimize file scanning.
+
+### 4.2 `get_all_overture_types`
+
+```python
+def get_all_overture_types() -> list[str]
+```
+
+Returns all 15 type keys in deterministic order.
+
+### 4.3 `geodataframe` (optional, not in public API)
+
+```python
+def geodataframe(
+    type: str,
+    bbox: ...,
+    release: str | None = None,
+    ...
+) -> GeoDataFrame
+```
+
+Requires `geopandas` extra (`pip install overturemaps[geopandas]`). Raises `ImportError` with install hint if `geopandas` not present.
+
+### 4.4 `geoarrow_schema_adapter`
+
+```python
+def geoarrow_schema_adapter(schema: pa.Schema) -> pa.Schema
+```
+
+Tags the `geometry` column with `ARROW:extension:name = geoarrow.wkb`. Geometry stored as raw WKB binary in Parquet; this adapter makes it interpretable by downstream GeoArrow consumers (geopandas, GDAL, etc.) without re-serialization.
+
+---
+
+## 5. CLI Specification
+
+Entry point: `overturemaps`
+
+**Naked run (no subcommand)**: Prints a blue ASCII art "Overture Maps" banner (via `pyfiglet`, `slant` font) and version string to stderr, then prints standard help text to stdout.
+
+**Output colorization**: CLI uses `click.secho`/`click.style` for context-appropriate color. Warnings print yellow; errors print red; success indicators print green; release names print cyan; changelog added/modified/deleted counts print green/yellow/red respectively. `colorama` provides Windows ANSI compatibility automatically via Click.
+
+### 5.1 `download`
+
+```
+overturemaps download [OPTIONS]
+```
+
+| Option | Type | Required | Default | Notes |
+|---|---|---|---|---|
+| `--bbox` | `xmin,ymin,xmax,ymax` | No | global | Validated by `BboxParamType` |
+| `-f` | `geojson\|geojsonseq\|geoparquet` | Yes | — | Output format |
+| `-o / --output` | Path | Cond. | stdout | Required for `geoparquet` |
+| `-t / --type` | Choice | Yes | — | Must be one of 15 types |
+| `-r / --release` | str | No | latest | Validated against available releases |
+| `--stac / --no-stac` | flag | No | `--stac` | Use STAC index |
+| `--connect_timeout` | int | No | — | S3 connect timeout (seconds) |
+| `--request_timeout` | int | No | — | S3 request timeout (seconds) |
+
+**Warnings** (stderr, non-fatal):
+- No `--bbox`: warn with estimated download size (~1.2 TB GeoJSON / ~400 GB GeoParquet).
+- `--bbox` covers ≥ 1% of Earth's surface (`area_sq_deg ≥ 648`): warn with size estimates.
+
+**Post-download**: Writes `.state` sidecar (see §3.4). Uses resolved absolute path.
+
+**Geometry column**: If multiple geometry columns found in schema, raises `IOError`.
+
+**GeoParquet metadata**: Strips file-level `bbox` from metadata; adds `covering` sub-object when row-level `bbox` column present.
+
+### 5.2 `gers`
+
+```
+overturemaps gers [OPTIONS] GERS_ID
+```
+
+| Argument/Option | Notes |
+|---|---|
+| `GERS_ID` | Validated as UUID; normalized to lowercase-with-dashes |
+| `-f` | Format (same choices as `download`) |
+| `-o / --output` | Output path |
+| `--connect_timeout` | S3 timeout |
+| `--request_timeout` | S3 timeout |
+
+**Without `-f`**: queries GERS registry, prints feature info to stderr, exits 0.
+**With `-f`**: downloads and writes the feature.
+
+### 5.3 `releases`
+
+```
+overturemaps releases list
+overturemaps releases latest
+overturemaps releases check -o FILE
+overturemaps releases exists RELEASE
+```
+
+| Subcommand | Behavior | Exit codes |
+|---|---|---|
+| `list` | Print all releases, newest first | 0 |
+| `latest` | Print latest release string | 0 |
+| `check -o FILE` | Compare `.state` sidecar to latest release | 0 = up-to-date, 1 = stale or no state |
+| `exists RELEASE` | Print `true`/`false` | 0 = exists, 1 = not found |
+
+### 5.4 `changelog`
+
+```
+overturemaps changelog query [OPTIONS]
+overturemaps changelog summary [OPTIONS]
+```
+
+**`query`**:
+- Requires `--bbox`.
+- Requires at least one of `--theme` or `--type`.
+- `--theme` expands to all its types.
+- Prints per-type added/modified/deleted counts.
+- Prints totals when >1 type queried.
+
+**`summary`**:
+- No bbox; scans full theme/type.
+- Prints grand totals when >1 type in results.
+
+---
+
+## 6. Writer Specification
+
+All writers live in `overturemaps/writers.py`. All writers implement context manager protocol (`__enter__` / `__exit__`).
+
+### 6.0 `BaseGeoJSONWriter`
+
+Abstract base class managing file handle or stream lifecycle. Subclasses implement `write_feature(geom_str, props)` and optionally `finalize()`. Handles WKB → Shapely → GeoJSON geometry conversion and property column filtering (excludes `geometry` and `bbox` columns) in `write_batch()`.
+
+### 6.1 `GeoJSONSeqWriter`
+
+- One `{"type":"Feature","geometry":...,"properties":...}\n` per feature.
+- Geometry: WKB → Shapely → `shapely.to_geojson()`.
+- Properties: all non-`geometry`, non-`bbox` columns; `None` values excluded.
+- Serialization: `orjson` for properties; Shapely's native GeoJSON for geometry.
+
+### 6.2 `GeoJSONWriter`
+
+- Wraps output in `{"type":"FeatureCollection","features":[...]}`
+- Features comma-separated; `finalize()` closes the array and object.
+
+### 6.3 GeoParquet writer
+
+- Uses `pyarrow.parquet.ParquetWriter`.
+- Strips file-level `bbox` from Parquet metadata.
+- Adds `covering` → `bbox` sub-object in geo metadata when row-level `bbox` column present.
+- Applies `geoarrow_schema_adapter()` to tag geometry column.
+
+### 6.4 `copy(reader, writer)` contract
+
+- Lives in `writers.py`; imported into `cli.py` for use by the `download` and `gers` commands.
+- Iterates reader via `read_next_batch()` until `StopIteration`.
+- Skips empty batches (zero rows).
+- Reports progress to stderr via `tqdm`.
+
+---
+
+## 7. Changelog Module
+
+### 7.1 `query_changelog_ids`
+
+```python
+def query_changelog_ids(
+    release: str,
+    theme: str,
+    type_: str,
+    bbox: BBox,
+) -> dict[str, set[str]]
+```
+
+Returns `{change_type: set[id]}`. Keys present: `"added"`, `"data_changed"`, `"removed"`. `"unchanged"` excluded by filter.
+
+`FileNotFoundError` / "No such file" → returns `{}` (changelog not available for this release/type).
+
+### 7.2 `summarize_changelog`
+
+```python
+def summarize_changelog(
+    release: str,
+    theme: str,
+    type_: str,
+) -> dict[str, dict[str, dict[str, int]]]
+```
+
+Returns `{theme: {type: {change_type: count}}}`. Uses `pyarrow.compute.value_counts()` for efficiency; streams in batches.
+
+### 7.3 STAC Fallback Design
+
+`_get_changelog_files_from_stac()` returns `None` on any exception. Callers treat `None` as "fall back to direct S3 path scan." This design supports future STAC changelog integration without changing caller code.
+
+---
+
+## 8. Release Management
+
+### 8.1 `releases.py` contracts
+
+| Function | Contract |
+|---|---|
+| `list_releases()` | Non-empty; sorted newest-first |
+| `get_latest_release()` | Raises `RuntimeError` if no releases found |
+| `release_exists(r)` | Returns `False` on any network exception (never raises) |
+| `get_next_release(r)` | Returns `None` if `r` is latest, not found, or any exception |
+
+### 8.2 `ALL_RELEASES` proxy
+
+Lazy proxy on `core.ALL_RELEASES`. Supports `[]`, iteration, `len()`, `repr()`. Backwards compatibility shim — do not expand its interface.
+
+---
+
+## 9. State Management
+
+### 9.1 Sidecar convention
+
+State file path = `{output_path}.state` (e.g. `boston.geojson.state`).
+
+### 9.2 `save_state`
+
+- Creates parent directories if missing.
+- Writes JSON with `indent=2`.
+- `output` field stored as absolute, resolved path.
+
+### 9.3 `load_state`
+
+- Returns `None` on: missing file, `FileNotFoundError`, `JSONDecodeError`, `KeyError`.
+- Never raises. Callers must handle `None`.
+
+---
+
+## 10. Non-Functional Requirements
+
+### 10.1 Performance
+
+- **Streaming**: All data flows as `RecordBatch` streams. No full dataset loaded into memory.
+- **STAC index**: Default behavior. Skips file-scanning for non-intersecting Parquet shards.
+- **Predicate pushdown**: Row-group level via PyArrow; avoids reading non-matching row groups.
+- **Batch tuning**: `use_threads=True`, `batch_readahead=16`, `fragment_readahead=4`.
+- **GeoJSON throughput target**: ~10k points in ~31ms, ~10k polygons in ~44ms (Apple M-series baseline; see benchmarks).
+- **GERS binary search**: O(log n) over manifest; avoids scanning all registry shards.
+
+### 10.2 Reliability
+
+- **Anonymous S3**: No credentials to rotate, expire, or leak.
+- **STAC cache**: In-process only; no disk cache. TTL = process lifetime.
+- **Changelog fallback**: STAC stub failure is silent; direct S3 scan always attempted.
+- **Empty batch filtering**: Zero-row batches never passed to writers.
+- **State load failures**: Always `None`, never exception. Stale state = staleness check reports "update available", not a crash.
+
+### 10.3 Security
+
+- **No credentials stored**: S3 access is always anonymous.
+- **No remote code execution**: CLI only writes to local filesystem paths explicitly provided by user.
+- **No shell execution** in library code: all S3 I/O via PyArrow; no subprocess calls.
+- **GERS UUID normalization**: Input validated as UUID and normalized before use as filter predicate. Prevents injection into PyArrow filter expressions.
+- **Bbox validation**: All four float bounds validated before use in network requests or filter expressions.
+
+### 10.4 Compatibility
+
+- **Python**: 3.10, 3.11, 3.12, 3.13 (tested in CI matrix).
+- **StrEnum shim**: Python 3.10 compat required; do not use `enum.StrEnum` directly.
+- **geopandas**: Optional extra. Library must import and function without it. `HAS_GEOPANDAS` flag gates all geopandas usage. Stub `GeoDataFrame` class prevents `NameError` at import time.
+
+### 10.5 Observability
+
+- **Progress bar**: `tqdm` to stderr during `copy()`. Never to stdout.
+- **Warnings**: Large download warnings to stderr. Never suppress them.
+- **GERS info**: Registry lookup results printed to stderr (not stdout) when no format specified.
+
+---
+
+## 11. Dependency Constraints
+
+| Package | Min version | Rationale |
+|---|---|---|
+| `click` | 8.3.0 | CLI framework |
+| `colorama` | 0.4.6 | ANSI color compatibility on Windows (used automatically by Click) |
+| `orjson` | 3.9.0 | Fast JSON serialization for GeoJSON output |
+| `pyfiglet` | 1.0.2 | ASCII art banner on naked CLI invocation |
+| `pyarrow` | 15.0.2 | Parquet reading, S3 access, batch streaming |
+| `shapely` | 2.1.0 | WKB decoding, GeoJSON conversion |
+| `numpy` | 1.26.4 | PyArrow/Shapely interop; transitive dep of geopandas |
+| `tqdm` | 4.67.3 | Progress reporting |
+
+**Optional**:
+- `geopandas>=1.1.0` — `pip install overturemaps[geopandas]`
+
+**Dev**:
+- `pytest>=8.0.0`, `pytest-mock>=3.11.0`, `pytest-benchmark>=5.0.0`
+
+**Binary build** (dependency group `binary`; not installed by default):
+- `pyinstaller>=6.0`, `pyinstaller-hooks-contrib>=2024.10`
+
+---
+
+## 12. Testing Requirements
+
+### 12.1 Test categories
+
+| Marker | Scope | Network | CI execution |
+|---|---|---|---|
+| (none) | Unit | No | `pytest tests/ -m "not integration"` |
+| `integration` | Integration | Yes | CLI smoke test step only |
+| `slow` | Slow unit/bench | No | On-demand |
+
+### 12.2 Unit test coverage requirements
+
+- `BBox`: all serialization methods, all validation failure modes.
+- `Backend`: enum values, string coercion.
+- `PipelineState`: round-trip serialize/deserialize with and without bbox.
+- `BboxParamType`: valid input; 7 failure modes (wrong count, non-numeric, lon OOB, lat OOB, swapped x, swapped y); error messages must include usage examples.
+- `copy()`: all non-empty batches written; empty batches skipped; empty reader handled.
+- `download` state: output path stored as absolute resolved path.
+- `releases exists`: exit code 0 + "true" on found; exit code 1 + error on not found.
+- `save_state` / `load_state`: round-trip; missing file → None; bad JSON → None; creates nested dirs.
+- `_bbox_area_sq_deg()`: small box, full Earth.
+- Large bbox warning: fires at ≥1% Earth with correct size estimates.
+- No bbox warning: fires with correct size estimates.
+- `overturemaps.__main__`: importable without side effects; calls `cli()` when run as `__main__`; `python -m overturemaps --help` exits 0.
+
+### 12.3 Integration test coverage requirements
+
+- `list_releases()`: non-empty, sorted newest-first.
+- `get_latest_release()`: non-empty, contains `-` and `.`.
+- `release_exists()`: True for latest; False for `"invalid-release"`.
+- `get_next_release()`: None for latest; returns latest for second-to-latest.
+- GERS query: known UUID returns 1-row batch with `id`, `geometry`, `bbox`.
+- GERS query: non-existent UUID returns None.
+- `query_changelog_ids()`: small bbox returns dict of string sets.
+- `query_changelog_ids()`: ocean bbox returns all-empty sets.
+- `summarize_changelog()`: theme query returns nested dict with int counts.
+
+### 12.4 Benchmark baselines
+
+- 10k points GeoJSONSeq write: < 100ms (M-series target: ~31ms).
+- 10k polygons GeoJSONSeq write: < 150ms (M-series target: ~44ms).
+- Benchmarks must not require network access.
+
+---
+
+## 13. CI/CD Requirements
+
+### 13.1 Test workflow
+
+- Triggers: push to `main`, PR to `main`.
+- Matrix: Python 3.10, 3.11, 3.12, 3.13.
+- Steps: checkout → setup-uv (with cache) → `uv sync --dev` → `pytest tests/ -v` → CLI smoke test.
+- Smoke test: Boston buildings download to file, format `geojson`.
+- Rollup job `are-we-good` must always run; blocks merge on any matrix failure.
+- Concurrency: cancel-in-progress for same workflow+ref.
+
+### 13.2 Publish workflow
+
+- Production trigger: `release: published` GitHub event.
+- Test trigger: `workflow_dispatch`.
+- Build: `uv build` → artifact `dist/`.
+- Publish: `pypa/gh-action-pypi-publish` with OIDC (no stored API tokens).
+- `skip-existing: true` for test publishes; `attestations: true` always.
+- GitHub environments: `pypi` (production), `test-pypi`.
+
+### 13.3 Binary build workflow
+
+- Trigger: `release: published` GitHub event; `workflow_dispatch` for dry-run (uploads artifacts, does not attach to release).
+- Matrix: `ubuntu-latest` (linux-x86_64), `macos-latest` (macos-arm64), `macos-13` (macos-x86_64), `windows-latest` (windows-x86_64).
+- Tool: PyInstaller `--onefile` via `uv run pyinstaller`; `--collect-all pyarrow`, `--collect-all shapely`, `--collect-data pyfiglet`.
+- Entry point: `overturemaps/__main__.py`.
+- Output naming: `overturemaps-{version}-{target}[.exe]`.
+- Post-build smoke test: binary invoked with `--help`; must exit 0.
+- Release attachment: `gh release upload` with `contents: write` scoped to job level.
+
+### 13.4 Action pinning
+
+- All GitHub Actions pinned to full commit SHAs.
+- Dependabot monitors `github-actions` ecosystem weekly.
+- `actions/*` updates grouped into single PR.
+- PRs labeled `bot`; commit prefix `[CHORE](deps)`.
+
+---
+
+## 14. Code Quality and Best Practices
+
+### 14.1 What to enforce
+
+- **No linter config currently exists** (no ruff, black, mypy, pre-commit). Adding any of these is in-scope for quality improvement.
+- **Type annotations**: all public API functions should have full type annotations. Internal helpers may be unannotated where obvious.
+- **Docstrings**: not required by convention. Add only where behavior is non-obvious (e.g. STAC fallback design, binary search invariants).
+- **No mutable default arguments**.
+- **StrEnum shim** must be tested for Python 3.10 behavior.
+
+### 14.2 Error handling principles
+
+- **Validate at CLI boundary**: bbox, release string, GERS UUID, format choice. Library functions trust their callers.
+- **Fail fast on invalid type**: `type` not in `type_theme_map` should raise `KeyError` immediately, not silently produce an empty result.
+- **No silent swallowing** except: `load_state` (missing/corrupt state is non-fatal by design), `release_exists` (network errors = False), STAC fallback (fallback is the contract).
+- **`RuntimeError` for unrecoverable catalog failures** (e.g. no releases found).
+
+### 14.3 Output discipline
+
+- **stdout is data**: GeoJSON/GeoJSONSeq/GeoParquet content goes to stdout when no `-o`. No diagnostic output to stdout ever.
+- **stderr is user**: warnings, progress bars, GERS info, error messages all go to stderr.
+- **Exit codes**: 0 = success/true/up-to-date; 1 = failure/false/stale.
+
+### 14.4 Backwards compatibility
+
+- `ALL_RELEASES` lazy proxy retained for backwards compatibility. Do not remove.
+- `record_batch_reader` and `get_all_overture_types` are the public API contract. Signature changes require a version bump.
+- New optional parameters may be added with defaults without bumping major version.
+
+---
+
+## 15. Build and Release
+
+- **Build backend**: `hatchling`
+- **Package manager / task runner**: `uv` + `just`
+- **Version source**: `pyproject.toml` `version` field (not dynamic)
+- **Release cadence**: Tracks Overture Maps data releases (approximately monthly)
+- **PyPI package name**: `overturemaps`
+- **Standalone binaries**: Built via PyInstaller on release; attached to GitHub Release as assets for linux-x86_64, macos-arm64, macos-x86_64, windows-x86_64. Local build: `just build-binary`.
+- **`python -m overturemaps`**: Supported via `overturemaps/__main__.py`; same entry point used by PyInstaller.
+
+Version bump checklist:
+1. Update `version` in `pyproject.toml`.
+2. Create GitHub release with matching tag.
+3. Publish workflow auto-triggers on release event.

--- a/SPEC.md
+++ b/SPEC.md
@@ -138,10 +138,9 @@ def record_batch_reader(
     type: str,
     bbox: BBox | tuple | list | None = None,
     release: str | None = None,
-    *,
     connect_timeout: int | None = None,
     request_timeout: int | None = None,
-    stac: bool = True,
+    stac: bool = False,
 ) -> pyarrow.RecordBatchReader | None
 ```
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -128,7 +128,7 @@ Persisted as JSON sidecar beside output files.
 Exported from `overturemaps.__init__`:
 
 ```python
-from overturemaps import record_batch_reader, get_all_overture_types
+from overturemaps import geodataframe, record_batch_reader, get_all_overture_types
 ```
 
 ### 4.1 `record_batch_reader`

--- a/justfile
+++ b/justfile
@@ -1,6 +1,8 @@
 #!/usr/bin/env just --justfile
 
-latest_release := `curl -s https://stac.overturemaps.org | jq -r '.latest'`
+set windows-shell := ["powershell.exe", "-NoLogo", "-Command"]
+
+latest_release := "curl -s https://stac.overturemaps.org | jq -r '.latest'"
 
 @_default:
     {{ just_executable() }} --list
@@ -27,8 +29,8 @@ smoke-test:
         --bbox=-71.068,42.353,-71.058,42.363 \
         -f geojson \
         --type=building \
-        -o /tmp/boston-smoke.geojson
-    @echo "Output written to /tmp/boston-smoke.geojson"
+        -o boston-smoke.geojson
+    @echo "Output written to boston-smoke.geojson"
 
 # Run a smoke test for a given type (default: building)
 [group('test')]
@@ -38,8 +40,8 @@ smoke-test-type type='building':
         --bbox=-71.068,42.353,-71.058,42.363 \
         -f geojson \
         --type={{ type }} \
-        -o /tmp/boston-{{ type }}.geojson
-    @echo "Output written to /tmp/boston-{{ type }}.geojson"
+        -o boston-{{ type }}.geojson
+    @echo "Output written to boston-{{ type }}.geojson"
 
 # Show the latest Overture release
 [group('release')]
@@ -50,6 +52,18 @@ latest:
 [group('release')]
 releases:
     uv run overturemaps releases list
+
+# Build standalone binary for the current platform
+[group('build')]
+build-binary:
+    uv sync --group binary
+    uv run pyinstaller \
+        --onefile \
+        --name overturemaps \
+        --collect-all pyarrow \
+        --collect-all shapely \
+        --collect-data pyfiglet \
+        overturemaps/__main__.py
 
 # Build the package
 [group('build')]

--- a/justfile
+++ b/justfile
@@ -2,7 +2,7 @@
 
 set windows-shell := ["powershell.exe", "-NoLogo", "-Command"]
 
-latest_release := "curl -s https://stac.overturemaps.org | jq -r '.latest'"
+latest_release := `curl -s https://stac.overturemaps.org | jq -r '.latest'`
 
 @_default:
     {{ just_executable() }} --list

--- a/overturemaps/__init__.py
+++ b/overturemaps/__init__.py
@@ -1,1 +1,1 @@
-from .core import get_all_overture_types, record_batch_reader
+from .core import geodataframe, get_all_overture_types, record_batch_reader

--- a/overturemaps/__main__.py
+++ b/overturemaps/__main__.py
@@ -1,0 +1,4 @@
+from overturemaps.cli import cli
+
+if __name__ == "__main__":
+    cli()

--- a/overturemaps/cli.py
+++ b/overturemaps/cli.py
@@ -7,17 +7,12 @@ in a specified bounding box in a few different file formats.
 """
 
 import importlib.metadata
-import json
 import os
 import sys
 import uuid
 from datetime import datetime, timezone
 
 import click
-import orjson
-import pyarrow.parquet as pq
-import shapely
-from tqdm import tqdm
 
 from .changelog import query_changelog_ids, summarize_changelog
 from .core import (
@@ -31,51 +26,24 @@ from .core import (
 from .models import Backend, BBox, PipelineState
 from .releases import list_releases, release_exists
 from .state import get_state_path, load_state, save_state
-
-
-def get_writer(output_format, path, schema):
-    if output_format == "geojson":
-        writer = GeoJSONWriter(path)
-    elif output_format == "geojsonseq":
-        writer = GeoJSONSeqWriter(path)
-    elif output_format == "geoparquet":
-        # Update the geoparquet metadata to remove the file-level bbox which
-        # will no longer apply to this file. Since we cannot write the field at
-        # the end, just remove it as it's optional. Let the per-row bounding
-        # boxes do all the work.
-        metadata = schema.metadata
-        # extract geo metadata
-        geo = json.loads(metadata[b"geo"])
-        # the spec allows for multiple geom columns
-        geo_columns = geo["columns"]
-        if len(geo_columns) > 1:
-            raise IOError("Expected single geom column but encountered multiple.")
-        for geom_col_vals in geo_columns.values():
-            # geom level extents "bbox" is optional - remove if present
-            # since extracted data will have different extents
-            if "bbox" in geom_col_vals:
-                geom_col_vals.pop("bbox")
-            # add "covering" if there is a row level "bbox" column
-            # this facilitates spatial filters e.g. geopandas read_parquet
-            if "bbox" in schema.names:
-                geom_col_vals["covering"] = {
-                    "bbox": {
-                        "xmin": ["bbox", "xmin"],
-                        "ymin": ["bbox", "ymin"],
-                        "xmax": ["bbox", "xmax"],
-                        "ymax": ["bbox", "ymax"],
-                    }
-                }
-        metadata[b"geo"] = json.dumps(geo).encode("utf-8")
-        schema = schema.with_metadata(metadata)
-        writer = pq.ParquetWriter(path, schema)
-    return writer
+from .writers import copy, get_writer
 
 
 # Earth's total surface area in square degrees (360 * 180).
 EARTH_AREA_SQ_DEG = 64800
 # Threshold (fraction of Earth) above which we warn about a large bbox.
 LARGE_BBOX_THRESHOLD = 0.01  # 1% of Earth
+
+
+def _print_banner():
+    try:
+        import pyfiglet
+        banner = pyfiglet.figlet_format("Overture Maps", font="slant")
+    except Exception:
+        banner = "Overture Maps\n"
+    version = importlib.metadata.version("overturemaps")
+    click.secho(banner.rstrip(), fg="blue", bold=True, err=True)
+    click.secho(f"  v{version}  |  overturemaps.org\n", fg="bright_blue", err=True)
 
 
 def _bbox_area_sq_deg(xmin: float, ymin: float, xmax: float, ymax: float) -> float:
@@ -140,8 +108,12 @@ def validate_release(ctx, param, value):
 
     available_releases, _ = get_available_releases()
     if value not in available_releases:
-        raise click.BadParameter(
-            f"Release '{value}' not found. Available releases: {', '.join(available_releases)}"
+        raise click.UsageError(
+            f"Release '{value}' is no longer available. Overture keeps only the last "
+            f"two monthly releases (~60 days) for GDPR compliance. Older releases are "
+            f"automatically deleted from AWS S3 and Azure.\n\n"
+            f"Available releases: {', '.join(available_releases)}\n"
+            f"See all past release notes at: https://docs.overturemaps.org/release-calendar"
         )
     return value
 
@@ -152,21 +124,22 @@ def validate_gers_id(ctx, param, value):
         raise click.BadParameter("GERS ID cannot be empty")
 
     try:
-        # Try to parse as UUID - this validates the format
-        # Convert to standard format with dashes (lowercase with dashes)
         parsed_uuid = uuid.UUID(value)
         return str(parsed_uuid)
     except ValueError:
         raise click.BadParameter(f"GERS ID must be a valid UUID. Got: '{value}'")
 
 
-@click.group()
+@click.group(invoke_without_command=True)
 @click.version_option(
     version=importlib.metadata.version("overturemaps"),
     prog_name="overturemaps",
 )
-def cli():
-    pass
+@click.pass_context
+def cli(ctx):
+    if ctx.invoked_subcommand is None:
+        _print_banner()
+        click.echo(ctx.get_help())
 
 
 @cli.command()
@@ -206,25 +179,27 @@ def cli():
 def download(
     bbox, output_format, output, type_, release, connect_timeout, request_timeout, stac
 ):
-    # Warn when no bbox is provided
     if bbox is None:
-        click.echo(
+        click.secho(
             "Warning: No bounding box provided. Downloading the entire dataset "
             "for this type. The full Overture dataset is approximately "
             "1.2 TB as GeoJSON and 400 GB as GeoParquet.",
+            fg="yellow",
+            bold=True,
             err=True,
         )
     else:
-        # Warn if the bbox covers a large area
         area = _bbox_area_sq_deg(bbox[0], bbox[1], bbox[2], bbox[3])
         fraction = area / EARTH_AREA_SQ_DEG
         if fraction >= LARGE_BBOX_THRESHOLD:
             pct = fraction * 100
-            click.echo(
+            click.secho(
                 f"Warning: The bounding box covers ~{pct:.1f}% of Earth's surface. "
                 f"This may take a long time and use significant bandwidth. "
                 f"The full Overture dataset is approximately "
                 f"1.2 TB as GeoJSON and 400 GB as GeoParquet.",
+                fg="yellow",
+                bold=True,
                 err=True,
             )
 
@@ -233,10 +208,7 @@ def download(
             "Output file (-o/--output) is required when using geoparquet format"
         )
 
-    if output is None:
-        output_file = sys.stdout
-    else:
-        output_file = output
+    output_file = sys.stdout if output is None else output
 
     reader = record_batch_reader(
         type_, bbox, release, connect_timeout, request_timeout, stac
@@ -248,20 +220,19 @@ def download(
     with get_writer(output_format, output_file, schema=reader.schema) as writer:
         copy(reader, writer)
 
-    # Save state file if output was written to a file
     if output is not None:
         output_path = os.path.abspath(os.path.expanduser(output))
-
-        # Determine backend from output format
         backend = Backend(output_format)
-
-        # Get theme from type
         theme = type_theme_map.get(type_)
         if theme is None:
-            click.echo(f"Warning: Could not determine theme for type {type_}", err=True)
+            click.secho(
+                f"Warning: Could not determine theme for type {type_}",
+                fg="yellow",
+                bold=True,
+                err=True,
+            )
             return
 
-        # Create and save state
         state = PipelineState(
             last_release=release,
             last_run=datetime.now(timezone.utc).isoformat(),
@@ -278,7 +249,7 @@ def download(
 
         state_path = get_state_path(output)
         save_state(state, state_path)
-        click.echo(f"State saved to {state_path}", err=True)
+        click.secho(f"State saved to {state_path}", fg="bright_black", err=True)
 
 
 @cli.command()
@@ -307,20 +278,20 @@ def gers(ctx, gers_id, output_format, output, connect_timeout, request_timeout):
     """
     from .core import query_gers_registry
 
-    # First, query the registry to get feature information
     result = query_gers_registry(gers_id)
 
     if result is None:
-        # Error message already printed by query_gers_registry
         ctx.exit(1)
 
-    # If no format specified, we're done - just show the registry info
     if output_format is None:
-        click.echo(f"\nRegistry lookup complete for GERS ID: {gers_id}", err=True)
-        click.echo("To download the feature data, use -f/--format option.", err=True)
+        click.secho(
+            f"\nRegistry lookup complete for GERS ID: {gers_id}", fg="bright_black", err=True
+        )
+        click.secho(
+            "To download the feature data, use -f/--format option.", fg="bright_black", err=True
+        )
         return
 
-    # Format specified - proceed to download the feature
     if output_format == "geoparquet" and output is None:
         raise click.UsageError(
             "Output file (-o/--output) is required when using geoparquet format"
@@ -329,115 +300,20 @@ def gers(ctx, gers_id, output_format, output, connect_timeout, request_timeout):
     if output is None:
         output = sys.stdout
 
-    # Pass the registry result to avoid duplicate query
     reader = record_batch_reader_from_gers(
         gers_id, connect_timeout, request_timeout, registry_result=result
     )
 
     if reader is None:
-        click.echo(
+        click.secho(
             f"Could not fetch feature data for GERS ID '{gers_id}'",
+            fg="red",
             err=True,
         )
         ctx.exit(1)
 
     with get_writer(output_format, output, schema=reader.schema) as writer:
         copy(reader, writer)
-
-
-def copy(reader, writer):
-    with tqdm(total=None, unit=" rows", desc="Downloading", file=sys.stderr) as bar:
-        while True:
-            try:
-                batch = reader.read_next_batch()
-            except StopIteration:
-                break
-            if batch.num_rows > 0:
-                writer.write_batch(batch)
-                bar.update(batch.num_rows)
-
-
-class BaseGeoJSONWriter:
-    """
-    A base feature writer that manages either a file handle
-    or output stream. Subclasses should implement write_feature()
-    and finalize() if needed
-    """
-
-    def __init__(self, where):
-        self.file_handle = None
-        if isinstance(where, str):
-            self.file_handle = open(os.path.expanduser(where), "w")
-            self.writer = self.file_handle
-        else:
-            self.writer = where
-        self.is_open = True
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, exc_type, value, traceback):
-        self.close()
-
-    def close(self):
-        if not self.is_open:
-            return
-        self.finalize()
-        if self.file_handle:
-            self.file_handle.close()
-        self.is_open = False
-
-    def write_batch(self, batch):
-        if batch.num_rows == 0:
-            return
-
-        geom_strings = shapely.to_geojson(
-            shapely.from_wkb(batch.column("geometry").to_pylist())
-        )
-
-        prop_cols = [c for c in batch.schema.names if c not in ("geometry", "bbox")]
-        rows = batch.select(prop_cols).to_pylist()
-
-        for geom_str, row in zip(geom_strings, rows):
-            self.write_feature(geom_str, row)
-
-    def write_feature(self, geom_str, props):
-        pass
-
-    def finalize(self):
-        pass
-
-
-class GeoJSONSeqWriter(BaseGeoJSONWriter):
-    def write_feature(self, geom_str, props):
-        props_str = orjson.dumps(
-            {k: v for k, v in props.items() if v is not None}
-        ).decode()
-        self.writer.write(
-            f'{{"type":"Feature","geometry":{geom_str},"properties":{props_str}}}\n'
-        )
-
-
-class GeoJSONWriter(BaseGeoJSONWriter):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self._has_written_feature = False
-
-        self.writer.write('{"type": "FeatureCollection", "features": [\n')
-
-    def write_feature(self, geom_str, props):
-        props_str = orjson.dumps(
-            {k: v for k, v in props.items() if v is not None}
-        ).decode()
-        if self._has_written_feature:
-            self.writer.write(",\n")
-        self.writer.write(
-            f'{{"type":"Feature","geometry":{geom_str},"properties":{props_str}}}'
-        )
-        self._has_written_feature = True
-
-    def finalize(self):
-        self.writer.write("]}")
 
 
 @cli.group()
@@ -451,17 +327,20 @@ def releases_list():
     """List all available Overture Maps releases."""
     all_releases = list_releases()
     if not all_releases:
-        click.echo("No releases found.", err=True)
+        click.secho("No releases found.", fg="red", err=True)
         return
-    for release in all_releases:
-        click.echo(release)
+    for i, release in enumerate(all_releases):
+        if i == 0:
+            click.secho(release, fg="cyan", bold=True)  # latest
+        else:
+            click.echo(release)
 
 
 @releases.command(name="latest")
 def releases_latest():
     """Show the latest Overture Maps release."""
     latest = get_latest_release()
-    click.echo(latest)
+    click.secho(latest, fg="cyan", bold=True)
 
 
 @cli.group()
@@ -491,17 +370,14 @@ def changelog_query(bbox, theme, type_, release):
     """
     bbox_obj = BBox(xmin=bbox[0], ymin=bbox[1], xmax=bbox[2], ymax=bbox[3])
 
-    # Determine which theme/type combinations to query
     if theme and type_:
         if type_ not in type_theme_map:
             raise click.BadParameter(f"Unknown type '{type_}'", param_hint="--type")
         themes_types = [(theme, type_)]
     elif theme:
-        # Get all types for this theme
         types = [t for t, th in type_theme_map.items() if th == theme]
         themes_types = [(theme, t) for t in types]
     elif type_:
-        # Get theme for this type
         if type_ not in type_theme_map:
             raise click.BadParameter(f"Unknown type '{type_}'", param_hint="type")
         theme = type_theme_map[type_]
@@ -513,7 +389,7 @@ def changelog_query(bbox, theme, type_, release):
     total_modified = 0
     total_deleted = 0
 
-    click.echo(f"Querying changelog for release {release}...")
+    click.secho(f"Querying changelog for release {release}...", fg="bright_black")
     click.echo()
 
     for theme_name, type_name in themes_types:
@@ -528,17 +404,17 @@ def changelog_query(bbox, theme, type_, release):
         total_deleted += deleted
 
         if added + modified + deleted > 0:
-            click.echo(f"{theme_name}/{type_name}:")
-            click.echo(f"  Added:    {added}")
-            click.echo(f"  Modified: {modified}")
-            click.echo(f"  Deleted:  {deleted}")
+            click.secho(f"{theme_name}/{type_name}:", bold=True)
+            click.secho(f"  Added:    {added}", fg="green")
+            click.secho(f"  Modified: {modified}", fg="yellow")
+            click.secho(f"  Deleted:  {deleted}", fg="red")
             click.echo()
 
     if len(themes_types) > 1:
-        click.echo("Total:")
-        click.echo(f"  Added:    {total_added}")
-        click.echo(f"  Modified: {total_modified}")
-        click.echo(f"  Deleted:  {total_deleted}")
+        click.secho("Total:", bold=True)
+        click.secho(f"  Added:    {total_added}", fg="green", bold=True)
+        click.secho(f"  Modified: {total_modified}", fg="yellow", bold=True)
+        click.secho(f"  Deleted:  {total_deleted}", fg="red", bold=True)
 
 
 @changelog.command(name="summary")
@@ -560,7 +436,7 @@ def changelog_summary(theme, type_, release):
         overturemaps changelog summary --type=building
         overturemaps changelog summary  # All themes/types
     """
-    click.echo(f"Summarizing changelog for release {release}...")
+    click.secho(f"Summarizing changelog for release {release}...", fg="bright_black")
     click.echo()
 
     try:
@@ -572,16 +448,22 @@ def changelog_summary(theme, type_, release):
 
     for theme_name, types_data in results.items():
         for type_name, change_counts in types_data.items():
-            click.echo(f"{theme_name}/{type_name}:")
+            click.secho(f"{theme_name}/{type_name}:", bold=True)
             for change_type, count in sorted(change_counts.items()):
-                click.echo(f"  {change_type}: {count}")
+                fg = {"added": "green", "data_changed": "yellow", "removed": "red"}.get(
+                    change_type
+                )
+                click.secho(f"  {change_type}: {count}", fg=fg)
                 grand_totals[change_type] = grand_totals.get(change_type, 0) + count
             click.echo()
 
     if len(results) > 1 or (len(results) == 1 and len(list(results.values())[0]) > 1):
-        click.echo("Grand Total:")
+        click.secho("Grand Total:", bold=True)
         for change_type, count in sorted(grand_totals.items()):
-            click.echo(f"  {change_type}: {count}")
+            fg = {"added": "green", "data_changed": "yellow", "removed": "red"}.get(
+                change_type
+            )
+            click.secho(f"  {change_type}: {count}", fg=fg, bold=True)
 
 
 @releases.command(name="check")
@@ -593,20 +475,22 @@ def releases_check(ctx, output):
     state = load_state(state_path)
 
     if state is None:
-        click.echo(f"No state file found at {state_path}", err=True)
-        click.echo("Cannot determine current release version.", err=True)
+        click.secho(f"No state file found at {state_path}", fg="red", err=True)
+        click.secho("Cannot determine current release version.", fg="red", err=True)
         ctx.exit(1)
 
     latest = get_latest_release()
 
-    click.echo(f"Current release: {state.last_release}")
-    click.echo(f"Latest release:  {latest}")
+    click.echo(
+        "Current release: " + click.style(state.last_release, fg="cyan", bold=True)
+    )
+    click.echo("Latest release:  " + click.style(latest, fg="cyan", bold=True))
 
     if state.last_release == latest:
-        click.echo("✓ Up to date")
+        click.secho("✓ Up to date", fg="green", bold=True)
         ctx.exit(0)
     else:
-        click.echo("✗ Update available")
+        click.secho("✗ Update available", fg="yellow", bold=True)
         ctx.exit(1)
 
 
@@ -616,7 +500,7 @@ def releases_exists(release):
     """Check whether a release exists."""
     if not release_exists(release):
         raise click.ClickException(f"Release '{release}' not found")
-    click.echo("true")
+    click.secho("true", fg="green")
 
 
 if __name__ == "__main__":

--- a/overturemaps/writers.py
+++ b/overturemaps/writers.py
@@ -110,10 +110,14 @@ class BaseGeoJSONWriter:
             self.write_feature(geom_str, row)
 
     def write_feature(self, geom_str, props):
-        pass
+        raise NotImplementedError(
+            f"{self.__class__.__name__}.write_feature() must be implemented by subclasses"
+        )
 
     def finalize(self):
-        pass
+        raise NotImplementedError(
+            f"{self.__class__.__name__}.finalize() must be implemented by subclasses"
+        )
 
 
 class GeoJSONSeqWriter(BaseGeoJSONWriter):

--- a/overturemaps/writers.py
+++ b/overturemaps/writers.py
@@ -127,6 +127,9 @@ class BaseGeoJSONWriter:
 
 
 class GeoJSONSeqWriter(BaseGeoJSONWriter):
+    def finalize(self):
+        pass  # GeoJSONSeq has no closing footer
+
     def write_feature(self, geom_str, props):
         props_str = orjson.dumps(
             {k: v for k, v in props.items() if v is not None}

--- a/overturemaps/writers.py
+++ b/overturemaps/writers.py
@@ -1,0 +1,147 @@
+"""
+Writers and data pipeline for Overture Maps output formats.
+
+Implements the context-manager writer protocol and the copy() pipeline
+that streams RecordBatches from a reader to a writer.
+"""
+
+import json
+import os
+import sys
+
+import orjson
+import pyarrow.parquet as pq
+import shapely
+from tqdm import tqdm
+
+
+def get_writer(output_format, path, schema):
+    if output_format == "geojson":
+        return GeoJSONWriter(path)
+    elif output_format == "geojsonseq":
+        return GeoJSONSeqWriter(path)
+    elif output_format == "geoparquet":
+        # Update the geoparquet metadata to remove the file-level bbox which
+        # will no longer apply to this file. Since we cannot write the field at
+        # the end, just remove it as it's optional. Let the per-row bounding
+        # boxes do all the work.
+        metadata = schema.metadata
+        geo = json.loads(metadata[b"geo"])
+        geo_columns = geo["columns"]
+        if len(geo_columns) > 1:
+            raise IOError("Expected single geom column but encountered multiple.")
+        for geom_col_vals in geo_columns.values():
+            # geom level extents "bbox" is optional - remove if present
+            # since extracted data will have different extents
+            if "bbox" in geom_col_vals:
+                geom_col_vals.pop("bbox")
+            # add "covering" if there is a row level "bbox" column
+            # this facilitates spatial filters e.g. geopandas read_parquet
+            if "bbox" in schema.names:
+                geom_col_vals["covering"] = {
+                    "bbox": {
+                        "xmin": ["bbox", "xmin"],
+                        "ymin": ["bbox", "ymin"],
+                        "xmax": ["bbox", "xmax"],
+                        "ymax": ["bbox", "ymax"],
+                    }
+                }
+        metadata[b"geo"] = json.dumps(geo).encode("utf-8")
+        schema = schema.with_metadata(metadata)
+        return pq.ParquetWriter(path, schema)
+
+
+def copy(reader, writer):
+    with tqdm(
+        total=None, unit=" rows", desc="Downloading", file=sys.stderr, colour="blue"
+    ) as bar:
+        while True:
+            try:
+                batch = reader.read_next_batch()
+            except StopIteration:
+                break
+            if batch.num_rows > 0:
+                writer.write_batch(batch)
+                bar.update(batch.num_rows)
+
+
+class BaseGeoJSONWriter:
+    """
+    A base feature writer that manages either a file handle
+    or output stream. Subclasses should implement write_feature()
+    and finalize() if needed.
+    """
+
+    def __init__(self, where):
+        self.file_handle = None
+        if isinstance(where, str):
+            self.file_handle = open(os.path.expanduser(where), "w")
+            self.writer = self.file_handle
+        else:
+            self.writer = where
+        self.is_open = True
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, value, traceback):
+        self.close()
+
+    def close(self):
+        if not self.is_open:
+            return
+        self.finalize()
+        if self.file_handle:
+            self.file_handle.close()
+        self.is_open = False
+
+    def write_batch(self, batch):
+        if batch.num_rows == 0:
+            return
+
+        geom_strings = shapely.to_geojson(
+            shapely.from_wkb(batch.column("geometry").to_pylist())
+        )
+
+        prop_cols = [c for c in batch.schema.names if c not in ("geometry", "bbox")]
+        rows = batch.select(prop_cols).to_pylist()
+
+        for geom_str, row in zip(geom_strings, rows):
+            self.write_feature(geom_str, row)
+
+    def write_feature(self, geom_str, props):
+        pass
+
+    def finalize(self):
+        pass
+
+
+class GeoJSONSeqWriter(BaseGeoJSONWriter):
+    def write_feature(self, geom_str, props):
+        props_str = orjson.dumps(
+            {k: v for k, v in props.items() if v is not None}
+        ).decode()
+        self.writer.write(
+            f'{{"type":"Feature","geometry":{geom_str},"properties":{props_str}}}\n'
+        )
+
+
+class GeoJSONWriter(BaseGeoJSONWriter):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._has_written_feature = False
+        self.writer.write('{"type": "FeatureCollection", "features": [\n')
+
+    def write_feature(self, geom_str, props):
+        props_str = orjson.dumps(
+            {k: v for k, v in props.items() if v is not None}
+        ).decode()
+        if self._has_written_feature:
+            self.writer.write(",\n")
+        self.writer.write(
+            f'{{"type":"Feature","geometry":{geom_str},"properties":{props_str}}}'
+        )
+        self._has_written_feature = True
+
+    def finalize(self):
+        self.writer.write("]}")

--- a/overturemaps/writers.py
+++ b/overturemaps/writers.py
@@ -49,6 +49,12 @@ def get_writer(output_format, path, schema):
         metadata[b"geo"] = json.dumps(geo).encode("utf-8")
         schema = schema.with_metadata(metadata)
         return pq.ParquetWriter(path, schema)
+    else:
+        supported = ("geojson", "geojsonseq", "geoparquet")
+        raise ValueError(
+            f"Unknown output format {output_format!r}. "
+            f"Supported formats: {', '.join(supported)}"
+        )
 
 
 def copy(reader, writer):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,9 @@ requires-python = ">=3.10"
 keywords = ["geospatial", "mapping", "GIS", "geojson", "shapely", "parquet", "opendata", "overture", "maps"]
 dependencies = [
     "click>=8.3.0",
+    "colorama>=0.4.6",
     "orjson>=3.9.0",
+    "pyfiglet>=1.0.2",
     "pyarrow>=15.0.2",
     "shapely>=2.1.0",
     # numpy is not directly imported in the codebase, but we include it as a dependency
@@ -44,6 +46,10 @@ dev = [
     "pytest>=8.0.0",
     "pytest-mock>=3.11.0",
     "pytest-benchmark>=5.0.0",
+]
+binary = [
+    "pyinstaller>=6.0",
+    "pyinstaller-hooks-contrib>=2024.10",
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "overturemaps"
-version = "0.20.0"
+version = "0.21.0"
 description = "Python tools for interacting with Overture Maps (overturemaps.org) data."
 authors = [
     {name = "Jacob Wasserman", email = "jwasserman@meta.com"}

--- a/tests/test_cli_download.py
+++ b/tests/test_cli_download.py
@@ -227,3 +227,31 @@ def test_download_no_warning_on_small_bbox(monkeypatch):
     )
     assert result.exit_code == 0
     assert "Warning" not in result.output
+
+
+def test_download_invalid_release_explains_retention_policy(monkeypatch):
+    """download --release with an old release should explain the retention policy."""
+    monkeypatch.setattr(
+        "overturemaps.cli.get_available_releases",
+        lambda: (["2026-03-18.0", "2026-02-18.0"], "2026-03-18.0"),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "download",
+            "-f",
+            "geojson",
+            "-t",
+            "building",
+            "--release",
+            "2024-07-22.0",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "no longer available" in result.output
+    assert "GDPR" in result.output
+    assert "60 days" in result.output
+    assert "2026-03-18.0" in result.output
+    assert "docs.overturemaps.org/release-calendar" in result.output

--- a/tests/test_cli_gers.py
+++ b/tests/test_cli_gers.py
@@ -1,0 +1,32 @@
+"""Tests for GERS CLI argument validation."""
+
+import click
+import pytest
+
+from overturemaps.cli import validate_gers_id
+
+
+def test_validate_gers_id_valid_uuid():
+    result = validate_gers_id(None, None, "0b7fc702-5b1c-4bf2-abc1-b8f3b6ae2e76")
+    assert result == "0b7fc702-5b1c-4bf2-abc1-b8f3b6ae2e76"
+
+
+def test_validate_gers_id_normalizes_uppercase():
+    """uuid.UUID normalizes uppercase input to lowercase."""
+    result = validate_gers_id(None, None, "0B7FC702-5B1C-4BF2-ABC1-B8F3B6AE2E76")
+    assert result == "0b7fc702-5b1c-4bf2-abc1-b8f3b6ae2e76"
+
+
+def test_validate_gers_id_empty_raises():
+    with pytest.raises(click.BadParameter, match="cannot be empty"):
+        validate_gers_id(None, None, "")
+
+
+def test_validate_gers_id_not_uuid_raises():
+    with pytest.raises(click.BadParameter, match="valid UUID"):
+        validate_gers_id(None, None, "not-a-uuid")
+
+
+def test_validate_gers_id_partial_uuid_raises():
+    with pytest.raises(click.BadParameter, match="valid UUID"):
+        validate_gers_id(None, None, "0b7fc702-5b1c")

--- a/tests/test_cli_releases.py
+++ b/tests/test_cli_releases.py
@@ -3,6 +3,90 @@
 from click.testing import CliRunner
 
 from overturemaps.cli import cli
+from overturemaps.models import Backend, PipelineState
+
+
+def test_releases_list(monkeypatch):
+    """`releases list` prints all releases."""
+    monkeypatch.setattr(
+        "overturemaps.cli.list_releases",
+        lambda: ["2025-01-01.0", "2024-12-01.0", "2024-11-01.0"],
+    )
+    runner = CliRunner()
+    result = runner.invoke(cli, ["releases", "list"])
+    assert result.exit_code == 0
+    assert "2025-01-01.0" in result.output
+    assert "2024-12-01.0" in result.output
+    assert "2024-11-01.0" in result.output
+
+
+def test_releases_list_empty(monkeypatch):
+    """`releases list` handles empty list without crashing."""
+    monkeypatch.setattr("overturemaps.cli.list_releases", lambda: [])
+    runner = CliRunner()
+    result = runner.invoke(cli, ["releases", "list"])
+    assert result.exit_code == 0
+
+
+def test_releases_latest(monkeypatch):
+    """`releases latest` prints the latest release."""
+    monkeypatch.setattr("overturemaps.cli.get_latest_release", lambda: "2025-01-01.0")
+    runner = CliRunner()
+    result = runner.invoke(cli, ["releases", "latest"])
+    assert result.exit_code == 0
+    assert "2025-01-01.0" in result.output
+
+
+def test_releases_check_up_to_date(monkeypatch, tmp_path):
+    """`releases check` exits 0 when file matches latest release."""
+    output_file = tmp_path / "out.geojson"
+    output_file.touch()
+    mock_state = PipelineState(
+        last_release="2025-01-01.0",
+        last_run="2025-01-01T00:00:00Z",
+        theme="buildings",
+        type="building",
+        bbox=None,
+        backend=Backend.geojson,
+        output=str(output_file),
+    )
+    monkeypatch.setattr("overturemaps.cli.load_state", lambda path: mock_state)
+    monkeypatch.setattr("overturemaps.cli.get_latest_release", lambda: "2025-01-01.0")
+    runner = CliRunner()
+    result = runner.invoke(cli, ["releases", "check", "-o", str(output_file)])
+    assert result.exit_code == 0
+    assert "Up to date" in result.output
+
+
+def test_releases_check_update_available(monkeypatch, tmp_path):
+    """`releases check` exits 1 when a newer release exists."""
+    output_file = tmp_path / "out.geojson"
+    output_file.touch()
+    mock_state = PipelineState(
+        last_release="2024-11-01.0",
+        last_run="2024-11-01T00:00:00Z",
+        theme="buildings",
+        type="building",
+        bbox=None,
+        backend=Backend.geojson,
+        output=str(output_file),
+    )
+    monkeypatch.setattr("overturemaps.cli.load_state", lambda path: mock_state)
+    monkeypatch.setattr("overturemaps.cli.get_latest_release", lambda: "2025-01-01.0")
+    runner = CliRunner()
+    result = runner.invoke(cli, ["releases", "check", "-o", str(output_file)])
+    assert result.exit_code == 1
+    assert "Update available" in result.output
+
+
+def test_releases_check_no_state_file(monkeypatch, tmp_path):
+    """`releases check` exits 1 when no state file found."""
+    output_file = tmp_path / "out.geojson"
+    output_file.touch()
+    monkeypatch.setattr("overturemaps.cli.load_state", lambda path: None)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["releases", "check", "-o", str(output_file)])
+    assert result.exit_code == 1
 
 
 def test_releases_exists_true(monkeypatch):

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -1,6 +1,6 @@
 """Tests for the copy() function."""
 
-from overturemaps.cli import copy
+from overturemaps.writers import copy
 
 
 class _FakeBatch:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,116 @@
+"""Tests for pure (no-network) functions in core.py."""
+
+import pyarrow as pa
+import pytest
+
+from overturemaps.core import (
+    _binary_search_manifest,
+    _coerce_bbox,
+    _dataset_path,
+    geoarrow_schema_adapter,
+    get_all_overture_types,
+    type_theme_map,
+)
+from overturemaps.models import BBox
+
+
+class TestCoerceBbox:
+    def test_none_returns_none(self):
+        assert _coerce_bbox(None) is None
+
+    def test_bbox_instance_passthrough(self):
+        bbox = BBox(xmin=1.0, ymin=2.0, xmax=3.0, ymax=4.0)
+        assert _coerce_bbox(bbox) is bbox
+
+    def test_from_tuple(self):
+        result = _coerce_bbox((-71.1, 42.3, -71.0, 42.4))
+        assert isinstance(result, BBox)
+        assert result.xmin == -71.1
+        assert result.ymin == 42.3
+        assert result.xmax == -71.0
+        assert result.ymax == 42.4
+
+    def test_from_list(self):
+        result = _coerce_bbox([-71.1, 42.3, -71.0, 42.4])
+        assert isinstance(result, BBox)
+        assert result.ymin == 42.3
+
+    def test_wrong_length_raises(self):
+        with pytest.raises(ValueError):
+            _coerce_bbox((1.0, 2.0, 3.0))
+
+
+class TestDatasetPath:
+    def test_building_contains_theme_and_type(self):
+        path = _dataset_path("building", "2025-01-22.0")
+        assert "buildings" in path
+        assert "building" in path
+        assert "2025-01-22.0" in path
+
+    def test_path_starts_with_s3_bucket(self):
+        path = _dataset_path("place", "2025-01-22.0")
+        assert path.startswith("overturemaps-us-west-2/release/")
+        assert "places" in path
+        assert "place" in path
+
+
+class TestBinarySearchManifest:
+    def test_first_file(self):
+        manifest = [("file1.parquet", "bbb"), ("file2.parquet", "ddd")]
+        assert _binary_search_manifest(manifest, "aaa") == "file1.parquet"
+
+    def test_middle_file(self):
+        manifest = [
+            ("file1.parquet", "bbb"),
+            ("file2.parquet", "ddd"),
+            ("file3.parquet", "fff"),
+        ]
+        assert _binary_search_manifest(manifest, "ccc") == "file2.parquet"
+
+    def test_exact_max_id_matches_file(self):
+        manifest = [("file1.parquet", "bbb"), ("file2.parquet", "ddd")]
+        assert _binary_search_manifest(manifest, "bbb") == "file1.parquet"
+
+    def test_last_file(self):
+        manifest = [("file1.parquet", "bbb"), ("file2.parquet", "ddd")]
+        assert _binary_search_manifest(manifest, "ddd") == "file2.parquet"
+
+    def test_not_found_returns_none(self):
+        manifest = [("file1.parquet", "bbb"), ("file2.parquet", "ddd")]
+        assert _binary_search_manifest(manifest, "zzz") is None
+
+    def test_empty_manifest_returns_none(self):
+        assert _binary_search_manifest([], "aaa") is None
+
+
+class TestGetAllOvertureTypes:
+    def test_returns_nonempty_list(self):
+        result = get_all_overture_types()
+        assert isinstance(result, list)
+        assert len(result) > 0
+
+    def test_includes_core_types(self):
+        types = get_all_overture_types()
+        for t in ("building", "place", "segment", "water", "land"):
+            assert t in types
+
+    def test_matches_type_theme_map_keys(self):
+        assert set(get_all_overture_types()) == set(type_theme_map.keys())
+
+
+class TestGeoarrowSchemaAdapter:
+    def test_adds_extension_metadata_to_geometry(self):
+        schema = pa.schema(
+            [pa.field("id", pa.string()), pa.field("geometry", pa.large_binary())]
+        )
+        result = geoarrow_schema_adapter(schema)
+        geom_field = result.field("geometry")
+        assert geom_field.metadata[b"ARROW:extension:name"] == b"geoarrow.wkb"
+
+    def test_non_geometry_fields_unchanged(self):
+        schema = pa.schema(
+            [pa.field("id", pa.string()), pa.field("geometry", pa.large_binary())]
+        )
+        result = geoarrow_schema_adapter(schema)
+        assert result.field("id").type == pa.string()
+        assert result.field("id").metadata is None

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,34 @@
+"""Tests for overturemaps/__main__.py (PyInstaller / python -m overturemaps entry point)."""
+
+import runpy
+import sys
+from unittest.mock import patch
+
+import pytest
+
+
+def test_main_invokes_cli():
+    """__main__.py calls cli() when executed as __main__."""
+    with patch("overturemaps.cli.cli") as mock_cli:
+        mock_cli.side_effect = SystemExit(0)
+        with pytest.raises(SystemExit):
+            runpy.run_module("overturemaps", run_name="__main__", alter_sys=True)
+        mock_cli.assert_called_once()
+
+
+def test_main_importable():
+    """overturemaps.__main__ is importable without side effects."""
+    import importlib
+
+    mod = importlib.import_module("overturemaps.__main__")
+    assert hasattr(mod, "cli")
+
+
+def test_python_m_overturemaps_help(capsys):
+    """python -m overturemaps --help exits 0 and prints usage."""
+    with pytest.raises(SystemExit) as exc_info:
+        with patch("sys.argv", ["overturemaps", "--help"]):
+            runpy.run_module("overturemaps", run_name="__main__", alter_sys=True)
+    assert exc_info.value.code == 0
+    captured = capsys.readouterr()
+    assert "Usage" in captured.out or "Usage" in captured.err

--- a/tests/test_writers.py
+++ b/tests/test_writers.py
@@ -1,0 +1,102 @@
+"""Tests for writers.py — GeoJSON writer classes and get_writer factory."""
+
+import io
+import json
+
+from overturemaps.writers import GeoJSONSeqWriter, GeoJSONWriter, get_writer
+
+
+class TestGeoJSONSeqWriter:
+    def test_write_single_feature(self):
+        buf = io.StringIO()
+        writer = GeoJSONSeqWriter(buf)
+        writer.write_feature('{"type":"Point","coordinates":[0,0]}', {"name": "test"})
+        obj = json.loads(buf.getvalue().strip())
+        assert obj["type"] == "Feature"
+        assert obj["geometry"]["type"] == "Point"
+        assert obj["properties"]["name"] == "test"
+
+    def test_filters_none_properties(self):
+        buf = io.StringIO()
+        writer = GeoJSONSeqWriter(buf)
+        writer.write_feature(
+            '{"type":"Point","coordinates":[0,0]}',
+            {"name": "test", "empty": None},
+        )
+        obj = json.loads(buf.getvalue().strip())
+        assert "empty" not in obj["properties"]
+        assert obj["properties"]["name"] == "test"
+
+    def test_multiple_features_newline_separated(self):
+        buf = io.StringIO()
+        writer = GeoJSONSeqWriter(buf)
+        writer.write_feature('{"type":"Point","coordinates":[0,0]}', {"id": 1})
+        writer.write_feature('{"type":"Point","coordinates":[1,1]}', {"id": 2})
+        lines = [line for line in buf.getvalue().splitlines() if line.strip()]
+        assert len(lines) == 2
+        assert json.loads(lines[0])["properties"]["id"] == 1
+        assert json.loads(lines[1])["properties"]["id"] == 2
+
+    def test_context_manager_closes_cleanly(self):
+        buf = io.StringIO()
+        with GeoJSONSeqWriter(buf) as writer:
+            writer.write_feature('{"type":"Point","coordinates":[0,0]}', {})
+        assert writer.is_open is False
+
+
+class TestGeoJSONWriter:
+    def test_empty_produces_valid_feature_collection(self):
+        buf = io.StringIO()
+        with GeoJSONWriter(buf) as writer:
+            pass
+        obj = json.loads(buf.getvalue())
+        assert obj["type"] == "FeatureCollection"
+        assert obj["features"] == []
+
+    def test_single_feature(self):
+        buf = io.StringIO()
+        with GeoJSONWriter(buf) as writer:
+            writer.write_feature(
+                '{"type":"Point","coordinates":[0,0]}', {"name": "a"}
+            )
+        obj = json.loads(buf.getvalue())
+        assert len(obj["features"]) == 1
+        assert obj["features"][0]["type"] == "Feature"
+        assert obj["features"][0]["properties"]["name"] == "a"
+
+    def test_multiple_features_valid_json(self):
+        buf = io.StringIO()
+        with GeoJSONWriter(buf) as writer:
+            writer.write_feature('{"type":"Point","coordinates":[0,0]}', {"id": 1})
+            writer.write_feature('{"type":"Point","coordinates":[1,1]}', {"id": 2})
+        obj = json.loads(buf.getvalue())
+        assert len(obj["features"]) == 2
+        assert obj["features"][1]["properties"]["id"] == 2
+
+    def test_filters_none_properties(self):
+        buf = io.StringIO()
+        with GeoJSONWriter(buf) as writer:
+            writer.write_feature(
+                '{"type":"Point","coordinates":[0,0]}',
+                {"name": "test", "empty": None},
+            )
+        obj = json.loads(buf.getvalue())
+        assert "empty" not in obj["features"][0]["properties"]
+
+    def test_context_manager_closes_cleanly(self):
+        buf = io.StringIO()
+        with GeoJSONWriter(buf) as writer:
+            pass
+        assert writer.is_open is False
+
+
+class TestGetWriter:
+    def test_geojson_returns_geojson_writer(self):
+        buf = io.StringIO()
+        with get_writer("geojson", buf, schema=None) as writer:
+            assert isinstance(writer, GeoJSONWriter)
+
+    def test_geojsonseq_returns_geojsonseq_writer(self):
+        buf = io.StringIO()
+        with get_writer("geojsonseq", buf, schema=None) as writer:
+            assert isinstance(writer, GeoJSONSeqWriter)

--- a/uv.lock
+++ b/uv.lock
@@ -8,6 +8,15 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "altgraph"
+version = "0.17.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/f8/97fdf103f38fed6792a1601dbc16cc8aac56e7459a9fff08c812d8ae177a/altgraph-0.17.5.tar.gz", hash = "sha256:c87b395dd12fabde9c99573a9749d67da8d29ef9de0125c7f536699b4a9bc9e7", size = 48428, upload-time = "2025-11-21T20:35:50.583Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/ba/000a1996d4308bc65120167c21241a3b205464a2e0b58deda26ae8ac21d1/altgraph-0.17.5-py2.py3-none-any.whl", hash = "sha256:f3a22400bce1b0c701683820ac4f3b159cd301acab067c51c653e06961600597", size = 21228, upload-time = "2025-11-21T20:35:49.444Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.1.4"
 source = { registry = "https://pypi.org/simple" }
@@ -75,6 +84,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "macholib"
+version = "1.16.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "altgraph" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/10/2f/97589876ea967487978071c9042518d28b958d87b17dceb7cdc1d881f963/macholib-1.16.4.tar.gz", hash = "sha256:f408c93ab2e995cd2c46e34fe328b130404be143469e41bc366c807448979362", size = 59427, upload-time = "2025-11-22T08:28:38.373Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/d1/a9f36f8ecdf0fb7c9b1e78c8d7af12b8c8754e74851ac7b94a8305540fc7/macholib-1.16.4-py2.py3-none-any.whl", hash = "sha256:da1a3fa8266e30f0ce7e97c6a54eefaae8edd1e5f86f3eb8b95457cae90265ea", size = 38117, upload-time = "2025-11-22T08:28:36.939Z" },
 ]
 
 [[package]]
@@ -312,10 +333,12 @@ version = "0.20.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
+    { name = "colorama" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "orjson" },
     { name = "pyarrow" },
+    { name = "pyfiglet" },
     { name = "shapely" },
     { name = "tqdm" },
 ]
@@ -326,6 +349,10 @@ geopandas = [
 ]
 
 [package.dev-dependencies]
+binary = [
+    { name = "pyinstaller" },
+    { name = "pyinstaller-hooks-contrib" },
+]
 dev = [
     { name = "pytest" },
     { name = "pytest-benchmark" },
@@ -335,16 +362,22 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "click", specifier = ">=8.3.0" },
+    { name = "colorama", specifier = ">=0.4.6" },
     { name = "geopandas", marker = "extra == 'geopandas'", specifier = ">=1.1.0" },
     { name = "numpy", specifier = ">=1.26.4" },
     { name = "orjson", specifier = ">=3.9.0" },
     { name = "pyarrow", specifier = ">=15.0.2" },
+    { name = "pyfiglet", specifier = ">=1.0.2" },
     { name = "shapely", specifier = ">=2.1.0" },
     { name = "tqdm", specifier = ">=4.67.3" },
 ]
 provides-extras = ["geopandas"]
 
 [package.metadata.requires-dev]
+binary = [
+    { name = "pyinstaller", specifier = ">=6.0" },
+    { name = "pyinstaller-hooks-contrib", specifier = ">=2024.10" },
+]
 dev = [
     { name = "pytest", specifier = ">=8.0.0" },
     { name = "pytest-benchmark", specifier = ">=5.0.0" },
@@ -423,6 +456,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pefile"
+version = "2024.8.26"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/4f/2750f7f6f025a1507cd3b7218691671eecfd0bbebebe8b39aa0fe1d360b8/pefile-2024.8.26.tar.gz", hash = "sha256:3ff6c5d8b43e8c37bb6e6dd5085658d658a7a0bdcd20b6a07b1fcfc1c4e9d632", size = 76008, upload-time = "2024-08-26T20:58:38.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/16/12b82f791c7f50ddec566873d5bdd245baa1491bac11d15ffb98aecc8f8b/pefile-2024.8.26-py3-none-any.whl", hash = "sha256:76f8b485dcd3b1bb8166f1128d395fa3d87af26360c2358fb75b80019b957c6f", size = 74766, upload-time = "2024-08-26T21:01:02.632Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -498,12 +540,62 @@ wheels = [
 ]
 
 [[package]]
+name = "pyfiglet"
+version = "1.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c8/e3/0a86276ad2c383ce08d76110a8eec2fe22e7051c4b8ba3fa163a0b08c428/pyfiglet-1.0.4.tar.gz", hash = "sha256:db9c9940ed1bf3048deff534ed52ff2dafbbc2cd7610b17bb5eca1df6d4278ef", size = 1560615, upload-time = "2025-08-15T18:32:47.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/5c/fe9f95abd5eaedfa69f31e450f7e2768bef121dbdf25bcddee2cd3087a16/pyfiglet-1.0.4-py3-none-any.whl", hash = "sha256:65b57b7a8e1dff8a67dc8e940a117238661d5e14c3e49121032bd404d9b2b39f", size = 1806118, upload-time = "2025-08-15T18:32:45.556Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pyinstaller"
+version = "6.20.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "altgraph" },
+    { name = "macholib", marker = "sys_platform == 'darwin'" },
+    { name = "packaging" },
+    { name = "pefile", marker = "sys_platform == 'win32'" },
+    { name = "pyinstaller-hooks-contrib" },
+    { name = "pywin32-ctypes", marker = "sys_platform == 'win32'" },
+    { name = "setuptools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/46/60/d03d52e6690d4e9caf333dcd14550cde634ce6c118b3bc8fa3112c3186fd/pyinstaller-6.20.0.tar.gz", hash = "sha256:95c5c7e03d5d61e9dfb8ef259c699cf492bb1041beb6dbe83696608cec07347a", size = 4048728, upload-time = "2026-04-22T20:59:36.96Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/e4/e228d6d1bbb7fd62dc660a8fb202a583b023d3a3624ca95d1a9290ee4d6a/pyinstaller-6.20.0-py3-none-macosx_10_13_universal2.whl", hash = "sha256:bf3be4e1284ee78ddccba5e29f99443a12a7b4673168288ffc4c9d38c6f7b90e", size = 1047642, upload-time = "2026-04-22T20:58:32.006Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/bd/afb631bcb3f9040efebd4f6d067f0828b51710818f69fb41a2d4b7787f52/pyinstaller-6.20.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:72ae9c1fdea134afa791f58bdc9a1934d5c7609753c111e0026bfc272b32b712", size = 742494, upload-time = "2026-04-22T20:58:36.285Z" },
+    { url = "https://files.pythonhosted.org/packages/76/08/0729a5bac14754150e5d83b39d87d842eb42b0bffcaa03dbad6252e23a39/pyinstaller-6.20.0-py3-none-manylinux2014_i686.whl", hash = "sha256:1031bcc307f3fbeffd4e162723e64d46dbf591c82dd0997413afb2a07328b941", size = 754191, upload-time = "2026-04-22T20:58:40.603Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/82/bc0ee4c7b97db1958eb651e0da9fb1e672e5ae53ca8867fd97701de52906/pyinstaller-6.20.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:8df3b3f347659fa2562d8d193a98ad4600133b8b8d07c268df89e4154376750e", size = 751902, upload-time = "2026-04-22T20:58:44.7Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e7/770002d6aaa54173881cb2c49bb195ba67b97bf39bac1cdf320f28401629/pyinstaller-6.20.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:b0d3cc9dd8120d448459bd3880a12e2f9774c51443af49047801446377999a59", size = 748634, upload-time = "2026-04-22T20:58:48.579Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/db/68ba1fccb71278b2124fb90b37b7c8c0bc4c1173fba45b94466df3d9cb7f/pyinstaller-6.20.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:03696bb6350177c6bc23bcaf78e71a33c4a89b6754dd90d1be2f318e978c918b", size = 748490, upload-time = "2026-04-22T20:58:52.749Z" },
+    { url = "https://files.pythonhosted.org/packages/03/0f/ac77ffa996a56be3d5c8f85734a007f8347240691657f9704e7de2527fa3/pyinstaller-6.20.0-py3-none-musllinux_1_1_aarch64.whl", hash = "sha256:6357f1699f6af84f37e7367f031d4f68abdba65543b83990c9e8f5a4cebed0b7", size = 747650, upload-time = "2026-04-22T20:58:57.093Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/56/1ee91c3a2bc10ca1f36da10a6fd55ff7efc4dec367171eb25992a827874f/pyinstaller-6.20.0-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:0ab39c690abad26ba148e8f664f0478acc82a733997f4f22e757774832802da9", size = 747413, upload-time = "2026-04-22T20:59:01.174Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/55/ae264339996953c4cdf9d89d916a0a8fa26a83cf917a742fff8b9d5f3fe8/pyinstaller-6.20.0-py3-none-win32.whl", hash = "sha256:9a7637e8e44b4387b13667fdcaac86ab6b29c446c16d34d8401539b81838759c", size = 1331584, upload-time = "2026-04-22T20:59:07.201Z" },
+    { url = "https://files.pythonhosted.org/packages/76/8c/300f57578882cce259bfb5ae56fda3b69caa3fe9df40a176c719920ea6e2/pyinstaller-6.20.0-py3-none-win_amd64.whl", hash = "sha256:d588844e890ee80c4365867f98146636e1849bbca8e4284bbf0c809aff0f161a", size = 1391851, upload-time = "2026-04-22T20:59:14.024Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/ea/b2f8e1642aecda78c0b75c7321f708e49e10bb3c00dd4f148c40761a1527/pyinstaller-6.20.0-py3-none-win_arm64.whl", hash = "sha256:bd53282c0a73e5c95573e1ddc8e5d564d4932bec91efbaed4dc5fdff9c2ae7f2", size = 1332259, upload-time = "2026-04-22T20:59:20.509Z" },
+]
+
+[[package]]
+name = "pyinstaller-hooks-contrib"
+version = "2026.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "setuptools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c7/fe/9278c29394bf69169febc21f96b4252c3ee7c8ec22c2fc545004bed47e71/pyinstaller_hooks_contrib-2026.4.tar.gz", hash = "sha256:766c281acb1ecc32e21c8c667056d7ebf5da0aabd5e30c219f9c2a283620eeaa", size = 173050, upload-time = "2026-03-31T14:10:51.188Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/f4/035fb8c06deff827f540a9a4ed9122c54e5376fca3e42eddf0c263730775/pyinstaller_hooks_contrib-2026.4-py3-none-any.whl", hash = "sha256:1de1a5e49a878122010b88c7e295502bc69776c157c4a4dc78741a4e6178b00f", size = 455496, upload-time = "2026-03-31T14:10:49.867Z" },
 ]
 
 [[package]]
@@ -739,6 +831,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f8/bf/abbd3cdfb8fbc7fb3d4d38d320f2441b1e7cbe29be4f23797b4a2b5d8aac/pytz-2025.2.tar.gz", hash = "sha256:360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3", size = 320884, upload-time = "2025-03-25T02:25:00.538Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/c4/34e93fe5f5429d7570ec1fa436f1986fb1f00c3e0f43a589fe2bbcd22c3f/pytz-2025.2-py2.py3-none-any.whl", hash = "sha256:5ddf76296dd8c44c26eb8f4b6f35488f3ccbf6fbbd7adee0b7262d43f0ec2f00", size = 509225, upload-time = "2025-03-25T02:24:58.468Z" },
+]
+
+[[package]]
+name = "pywin32-ctypes"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload-time = "2024-08-14T10:15:34.626Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload-time = "2024-08-14T10:15:33.187Z" },
+]
+
+[[package]]
+name = "setuptools"
+version = "82.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Notes

This was an exercise in spec-driven development, and so is a bit wider than a typical PR.

My initial idea was to make a Go port to get the cross-OS binary support, but this ended up being a lot lower lift + avoids any pitfalls from maintaining two codebases for the "same thing". The Windows .exe worked great locally, and I'll do some more testing via workflow_dispatch once the workflow is merged into `main` and runnable.

## Changes

1. Add functionality to the justfile & CI workflows to automate building of binaries for Mac/Linux/Windows. On creating the next GitHub Release, these will automatically built and attached to the release (fixes #116)
   - A later enhancement would be to auto-publish this to more package managers to increase the broad availability of it (winget, brew (again), choco, etc) 

3. Split implementation details from business logic (resolves #64) and add lib API usage instructions to the README

4. Create a SPEC file to allow this to be better maintained using spec-driven-development.

5. Add light colorizing for better usability + add ASCII banner for branding, for example:

   Banner when run w/out args:
   <img width="656" height="361" alt="{CB2E384E-815B-4933-9820-6719F42BBCB9}" src="https://github.com/user-attachments/assets/5ed7df72-3ea7-486d-8b32-c2c68f0fc51c" />

   Latest release in cyan:
   <img width="830" height="62" alt="{30065869-A5FA-4292-A23D-0E9ED821FEF1}" src="https://github.com/user-attachments/assets/64c9b0e3-e1f9-49d3-82e0-0818cf58467e" />

6. Improved overall test coverage

7. Improved error message for missing releases (Fixes #107) - will now return:
   ```
   Error: Release '2024-07-22.0' is no longer available. Overture keeps only the last two monthly 
   releases (~60 days) for GDPR compliance. Older releases are automatically deleted from AWS S3 and
   Azure.

   Available releases: 2026-03-18.0, 2026-02-18.0
   See all past release notes at: https://docs.overturemaps.org/release-calendar
   ```