### PR TITLE
[BUG] ID field is incorrectly put inside `properties`; should be top level attribute

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -32,7 +32,7 @@ jobs:
           - os: macos-latest
             target: macos-arm64
             ext: ""
-          - os: macos-13
+          - os: macos-26-intel
             target: macos-x86_64
             ext: ""
           - os: windows-latest

--- a/overturemaps/writers.py
+++ b/overturemaps/writers.py
@@ -131,11 +131,15 @@ class GeoJSONSeqWriter(BaseGeoJSONWriter):
         pass  # GeoJSONSeq has no closing footer
 
     def write_feature(self, geom_str, props):
-        props_str = orjson.dumps(
-            {k: v for k, v in props.items() if v is not None}
-        ).decode()
+        # GeoJSON Feature identity belongs at top-level "id", not under properties.
+        feature_id = props.get("id")
+        properties = {k: v for k, v in props.items() if k != "id" and v is not None}
+        props_str = orjson.dumps(properties).decode()
+        feature_id_str = (
+            f'"id":{orjson.dumps(feature_id).decode()},' if feature_id is not None else ""
+        )
         self.writer.write(
-            f'{{"type":"Feature","geometry":{geom_str},"properties":{props_str}}}\n'
+            f'{{{feature_id_str}"type":"Feature","geometry":{geom_str},"properties":{props_str}}}\n'
         )
 
 
@@ -146,13 +150,17 @@ class GeoJSONWriter(BaseGeoJSONWriter):
         self.writer.write('{"type": "FeatureCollection", "features": [\n')
 
     def write_feature(self, geom_str, props):
-        props_str = orjson.dumps(
-            {k: v for k, v in props.items() if v is not None}
-        ).decode()
+        # Keep feature id semantics consistent across both GeoJSON output modes.
+        feature_id = props.get("id")
+        properties = {k: v for k, v in props.items() if k != "id" and v is not None}
+        props_str = orjson.dumps(properties).decode()
+        feature_id_str = (
+            f'"id":{orjson.dumps(feature_id).decode()},' if feature_id is not None else ""
+        )
         if self._has_written_feature:
             self.writer.write(",\n")
         self.writer.write(
-            f'{{"type":"Feature","geometry":{geom_str},"properties":{props_str}}}'
+            f'{{{feature_id_str}"type":"Feature","geometry":{geom_str},"properties":{props_str}}}'
         )
         self._has_written_feature = True
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "overturemaps"
-version = "0.21.0"
+version = "1.0.0"
 description = "Python tools for interacting with Overture Maps (overturemaps.org) data."
 authors = [
     {name = "Jacob Wasserman", email = "jwasserman@meta.com"}

--- a/tests/test_writers.py
+++ b/tests/test_writers.py
@@ -34,8 +34,17 @@ class TestGeoJSONSeqWriter:
         writer.write_feature('{"type":"Point","coordinates":[1,1]}', {"id": 2})
         lines = [line for line in buf.getvalue().splitlines() if line.strip()]
         assert len(lines) == 2
-        assert json.loads(lines[0])["properties"]["id"] == 1
-        assert json.loads(lines[1])["properties"]["id"] == 2
+        assert json.loads(lines[0])["id"] == 1
+        assert json.loads(lines[1])["id"] == 2
+
+    def test_writes_top_level_id_not_properties(self):
+        buf = io.StringIO()
+        writer = GeoJSONSeqWriter(buf)
+        writer.write_feature('{"type":"Point","coordinates":[0,0]}', {"id": "abc", "name": "n"})
+        obj = json.loads(buf.getvalue().strip())
+        assert obj["id"] == "abc"
+        assert "id" not in obj["properties"]
+        assert obj["properties"]["name"] == "n"
 
     def test_context_manager_closes_cleanly(self):
         buf = io.StringIO()
@@ -71,7 +80,19 @@ class TestGeoJSONWriter:
             writer.write_feature('{"type":"Point","coordinates":[1,1]}', {"id": 2})
         obj = json.loads(buf.getvalue())
         assert len(obj["features"]) == 2
-        assert obj["features"][1]["properties"]["id"] == 2
+        assert obj["features"][1]["id"] == 2
+
+    def test_writes_top_level_id_not_properties(self):
+        buf = io.StringIO()
+        with GeoJSONWriter(buf) as writer:
+            writer.write_feature(
+                '{"type":"Point","coordinates":[0,0]}',
+                {"id": "abc", "name": "n"},
+            )
+        feature = json.loads(buf.getvalue())["features"][0]
+        assert feature["id"] == "abc"
+        assert "id" not in feature["properties"]
+        assert feature["properties"]["name"] == "n"
 
     def test_filters_none_properties(self):
         buf = io.StringIO()


### PR DESCRIPTION
## Changes

To fix this, we updated GeoJSONSeq writer to:

1. read id from each row
2. emit feature.id when present
3. exclude id from properties

## Testing

Added and updated tests to verify:

* id is present at feature top level
* id is not duplicated in properties
* existing writer behavior remains intact

## CI

This also includes a fix to the binary building CI workflow, which was previously targeting non-available mac-os versions (13).

A test validation run here: https://github.com/OvertureMaps/overturemaps-py/actions/runs/25168870645/job/73782376936

## Breaking Changes

Because this changes how the data is being returned, it should be considered a breaking change and will use a major version bump.