### PR TITLE
[BUG] Fix windows binary upload in CI

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -87,6 +87,7 @@ jobs:
 
       - name: Upload to release
         if: github.event_name == 'release'
+        shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ github.ref_name }}


### PR DESCRIPTION
To allow us to properly attach the .exe to the releases automatically.