### PR TITLE
[BUG] Fix release parsing for absolute STAC catalog hrefs

### DIFF
--- a/overturemaps/core.py
+++ b/overturemaps/core.py
@@ -2,6 +2,7 @@ import io
 import json
 import sys
 from typing import List, Optional, Tuple
+from urllib.parse import urlparse
 from urllib.request import urlopen
 
 import pyarrow as pa
@@ -73,8 +74,10 @@ def get_available_releases() -> Tuple[List[str], str]:
     for link in catalog.get("links", []):
         if link.get("rel") == "child":
             href = link.get("href", "")
-            # href format is "./2025-09-24.0/catalog.json"
-            release_version = href.strip("./").split("/")[0]
+            # href may be relative ("./2025-09-24.0/catalog.json") or absolute
+            # ("https://stac.overturemaps.org/2025-09-24.0/catalog.json").
+            segments = [s for s in urlparse(href).path.split("/") if s and s != "."]
+            release_version = segments[0] if segments else ""
             if release_version:
                 releases.append(release_version)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "overturemaps"
-version = "1.0.1"
+version = "1.0.2"
 description = "Python tools for interacting with Overture Maps (overturemaps.org) data."
 authors = [
     {name = "Jacob Wasserman", email = "jwasserman@meta.com"}

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -9,6 +9,7 @@ from overturemaps.core import (
     _dataset_path,
     geoarrow_schema_adapter,
     get_all_overture_types,
+    get_available_releases,
     type_theme_map,
 )
 from overturemaps.models import BBox
@@ -114,3 +115,49 @@ class TestGeoarrowSchemaAdapter:
         result = geoarrow_schema_adapter(schema)
         assert result.field("id").type == pa.string()
         assert result.field("id").metadata is None
+
+
+class TestGetAvailableReleases:
+    """Regression tests for parsing STAC catalog child link hrefs.
+
+    A prior implementation used ``href.strip("./").split("/")[0]``, which
+    assumed a relative href like ``./2025-09-24.0/catalog.json``. The live
+    STAC catalog started returning absolute hrefs, which that strip/split
+    silently mis-parsed into ``"https:"`` instead of the release ID. These
+    mock the catalog so the case is verified without depending on remote
+    catalog contents.
+    """
+
+    def test_relative_child_hrefs(self, monkeypatch):
+        catalog = {
+            "latest": "2025-09-24.0",
+            "links": [
+                {"rel": "child", "href": "./2025-09-24.0/catalog.json"},
+                {"rel": "child", "href": "./2025-08-20.0/catalog.json"},
+                {"rel": "self", "href": "./catalog.json"},
+            ],
+        }
+        monkeypatch.setattr("overturemaps.core._cached_stac_catalog", catalog)
+        releases, latest = get_available_releases()
+        assert sorted(releases) == ["2025-08-20.0", "2025-09-24.0"]
+        assert latest == "2025-09-24.0"
+
+    def test_absolute_child_hrefs(self, monkeypatch):
+        catalog = {
+            "latest": "2026-08-19.0",
+            "links": [
+                {
+                    "rel": "child",
+                    "href": "https://stac.overturemaps.org/2026-08-19.0/catalog.json",
+                },
+                {
+                    "rel": "child",
+                    "href": "https://stac.overturemaps.org/2026-07-22.0/catalog.json",
+                },
+                {"rel": "self", "href": "https://stac.overturemaps.org/catalog.json"},
+            ],
+        }
+        monkeypatch.setattr("overturemaps.core._cached_stac_catalog", catalog)
+        releases, latest = get_available_releases()
+        assert sorted(releases) == ["2026-07-22.0", "2026-08-19.0"]
+        assert latest == "2026-08-19.0"

--- a/uv.lock
+++ b/uv.lock
@@ -329,7 +329,7 @@ wheels = [
 
 [[package]]
 name = "overturemaps"
-version = "0.20.0"
+version = "1.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -357,6 +357,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-benchmark" },
     { name = "pytest-mock" },
+    { name = "ruff" },
 ]
 
 [package.metadata]
@@ -382,6 +383,7 @@ dev = [
     { name = "pytest", specifier = ">=8.0.0" },
     { name = "pytest-benchmark", specifier = ">=5.0.0" },
     { name = "pytest-mock", specifier = ">=3.11.0" },
+    { name = "ruff", specifier = ">=0.4.0" },
 ]
 
 [[package]]
@@ -840,6 +842,31 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload-time = "2024-08-14T10:15:34.626Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload-time = "2024-08-14T10:15:33.187Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.16.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/8f/d8074b1f25e003164087a8bfe79a0f1a3945135764dbb6aaab04103dcaf9/ruff-0.16.4.tar.gz", hash = "sha256:13171aa9d9af2240ee3504e639de73122c67e74036de5ba2e1d01422cd17e3dc", size = 4899731, upload-time = "2026-08-20T17:43:59.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ff/80/779895ef584e089d22f2c6df0d0e99a65ec2df0805f1fffd439415b8c1f0/ruff-0.16.4-py3-none-linux_armv6l.whl", hash = "sha256:df4075f71ddac40b9934af60c3ec8a53047dd5a5fdc43224e6e4e8e9a27cb6f7", size = 10006909, upload-time = "2026-08-20T17:43:16.888Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/e6/f553199b5e8927a05cb5c422d921fd0656b29ab976e91c44802107c6b0da/ruff-0.16.4-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:0c95538517af68004306b0fb3214ff2f2af67a65092aee77cd9eb86db6656604", size = 10240201, upload-time = "2026-08-20T17:43:19.337Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/70/4a6dc4bb34da4dee35e30f09bbd1bfbdd26f33b62fb9b8df31f08a199cd2/ruff-0.16.4-py3-none-macosx_11_0_arm64.whl", hash = "sha256:963f83df8e69e575b64d67dd447ebbc917db41a14bf38d4593a4183e7aaa8255", size = 9835122, upload-time = "2026-08-20T17:43:21.708Z" },
+    { url = "https://files.pythonhosted.org/packages/24/12/c6e22d686372c15bcb7af99831f1a1be96df696491babf4f24e4f942c527/ruff-0.16.4-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:32a5057c7ff3f6e6480a48fccfb3a412a690f48a3d03ac5cf08177d6c2da3ade", size = 9977162, upload-time = "2026-08-20T17:43:24.236Z" },
+    { url = "https://files.pythonhosted.org/packages/46/49/72b10ec912f5ab5854992eaf7aa7cd36729b6937d9dc4e0fb41b3bf428ec/ruff-0.16.4-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b3dce8d9b0c57c265b91885a66a567d8ea1372e8eb4e250fa8e5e3f579e99cff", size = 9829789, upload-time = "2026-08-20T17:43:26.966Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/80/0f30e32e7f6ee26edc39075502db9d368d788a44a79b55f763eb4ab03796/ruff-0.16.4-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7dc651db49283c69f8e72c834eec4fe5573e4c646856aebece0ce385dceb2a80", size = 10527949, upload-time = "2026-08-20T17:43:29.384Z" },
+    { url = "https://files.pythonhosted.org/packages/52/3d/86e8ad3542169e56cac3859a343afdb9df2ad54d35a59ce1e67baee83421/ruff-0.16.4-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3817b87dbcabc92f13b05019257c5b89b5b4d51b5fb20f56fb5235ceb723cd07", size = 11333695, upload-time = "2026-08-20T17:43:31.872Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/16/481c29b380c20a0054a8261066665e1b3488e23636c49d0a43e75975b9bb/ruff-0.16.4-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e9fce1499134b2c8c68e5166f95705a5812062bb93aacc5f9873bb1a27084bc7", size = 10727741, upload-time = "2026-08-20T17:43:34.596Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/b6/56bc0b8cf45b54b28b3a5e6381c8945d51b5b18adf659454c32295209a31/ruff-0.16.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f2d812e482f5a7e02eee26cd73d2a37ebbdf47d795ea63ba1b89110ae93e9fb3", size = 10286522, upload-time = "2026-08-20T17:43:37.288Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/8b/b345b4fb110f2fbe2bd31eabd271e5e8b3b7e4ee6c0e02f2dc6be78db000/ruff-0.16.4-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:6baaf984aa7976edf93d3b627fe2d1d22ee94bbca05fa6f90fc76d73924e3454", size = 10584182, upload-time = "2026-08-20T17:43:39.984Z" },
+    { url = "https://files.pythonhosted.org/packages/29/e5/827b34041c35f58774a9681a4213994c164fc987800f4dddabcf451da0bf/ruff-0.16.4-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:bdfcf0b28662eb890372d50f92c283bb94e67e7635ed93c7fd533970acff7b2b", size = 10134195, upload-time = "2026-08-20T17:43:42.351Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/10/d0bffcdd6729b87afc82ba0ef377173356a7dc8e972f5179968cf2fdf98c/ruff-0.16.4-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:b66b02cb9b04f537643cadf5768e5f98dc461890d530cb67113d71c8c76e605d", size = 9825821, upload-time = "2026-08-20T17:43:44.532Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/32/0db2a863b796ca62d83e92a07a3ccf00921b14db02059347576a2fda3d4b/ruff-0.16.4-py3-none-musllinux_1_2_i686.whl", hash = "sha256:8528bf9a4b291a60bf02ea453511e8ce6215bd2b982ee80405b66b008b6c30a0", size = 10267658, upload-time = "2026-08-20T17:43:46.989Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a0/fbdeb59e48c6261f523e56c8f12e9c08fbe693786595cc7e3959207a9232/ruff-0.16.4-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:fbd85d2875fdd67e833213a651f613bbf25303abf6aa822a5121f4531195678d", size = 10697071, upload-time = "2026-08-20T17:43:49.891Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/28/0c6dd865859c6d17bc8ccc34cb72b0e02d6c7eb25e8a1e22b5bea681e2c0/ruff-0.16.4-py3-none-win32.whl", hash = "sha256:312769988007aaeb8e189b443ccdd03c0e6374489e053467be6d96518ebff76e", size = 10021687, upload-time = "2026-08-20T17:43:52.281Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/03/e724450f621698117f9aa6dd241c94d0274ae96781378dc86745ae29f0e7/ruff-0.16.4-py3-none-win_amd64.whl", hash = "sha256:05d9d27a18c4bcbefada602480ec9e01e0bc949d432e0ced5df77edac195919c", size = 10567657, upload-time = "2026-08-20T17:43:54.78Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/fe/da8b9e1347696bb22120b77280ec5ce25d500ca5cb39d5ad6e5c18de19c1/ruff-0.16.4-py3-none-win_arm64.whl", hash = "sha256:a3a61621c9b6f6a89573e938a080e648f1695baa3f58570a3a707bc51ff65a21", size = 10451579, upload-time = "2026-08-20T17:43:57.135Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
CI on PR #138 (an unrelated Dependabot bump of `astral-sh/setup-uv`) is failing `test_release_exists` and `test_get_next_release` in `tests/test_releases.py`. The bump didn't cause it, this is a pre-existing bug also present on `main`, fixes #139.

`get_available_releases` in `overturemaps/core.py` extracted release IDs from the STAC catalog's `child` links with `href.strip("./").split("/")[0]`, assuming a relative href like `./2025-09-24.0/catalog.json`. The catalog at https://stac.overturemaps.org/catalog.json now returns absolute hrefs (e.g. `https://stac.overturemaps.org/2026-08-19.0/catalog.json`). `str.strip` only trims leading/trailing `.`/`/` characters, so it's a no-op on a string starting with `https:`, and `split("/")[0]` returns `"https:"` instead of the release ID.

Since `"https:"` sorts after any `YYYY-MM-DD.N` string, it landed first in the sorted release list, which broke lookups for the actual latest release.

Fixed by parsing the href's path with `urlparse` instead of a raw string strip, which handles both relative and absolute hrefs.

## Testing

`uv run pytest tests/` passes all 90 tests locally, including `test_releases.py::test_release_exists` and `test_releases.py::test_get_next_release`, which hit the live STAC catalog.
<!--:robot:-->